### PR TITLE
Fix package manifest file

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
 	<depend>rospack</depend>
 	<depend>roslib</depend>
 	<depend>roscpp</depend>
+	<depend>rosbash</depend>
 	<depend>rqt_gui</depend>
 	<depend>rqt_gui_cpp</depend>
 	<depend>std_msgs</depend>


### PR DESCRIPTION
rosrun (from rosbash) is required by the env-hooks for auto completion. Without that, sourcing setup.bash fails.