### PR TITLE
Indigo support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
 	cmake_modules
 	roslib
 	message_generation
+	pluginlib
 	rospack
 	rqt_gui
 	rqt_gui_cpp
@@ -38,6 +39,11 @@ include_directories(${CURSES_INCLUDE_DIRS})
 if(${roscpp_VERSION} VERSION_GREATER 1.12.8)
 	message(STATUS "roscpp is new enough, using SteadyTimer for timekeeping")
 	add_definitions(-DHAVE_STEADYTIMER=1)
+endif()
+
+if(${pluginlib_VERSION} VERSION_GREATER 1.11.1)
+	message(STATUS "using new pluginlib headers with .hpp extensions")
+	add_definitions(-DHAVE_PLUGINLIB_NEW_HEADERS=1)
 endif()
 
 add_executable(rosmon

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,18 @@ generate_messages(DEPENDENCIES
 
 catkin_package()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror")
+
 find_package(TinyXML REQUIRED)
 
 find_package(Curses REQUIRED)
 include_directories(${CURSES_INCLUDE_DIRS})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror")
+# Specific feature tests
+if(${roscpp_VERSION} VERSION_GREATER 1.12.8)
+	message(STATUS "roscpp is new enough, using SteadyTimer for timekeeping")
+	add_definitions(-DHAVE_STEADYTIMER=1)
+endif()
 
 add_executable(rosmon
 	src/main.cpp

--- a/src/gui/mon_gui.cpp
+++ b/src/gui/mon_gui.cpp
@@ -40,6 +40,12 @@ void MonGUI::initPlugin(qt_gui_cpp::PluginContext& ctx)
 
 	m_model = new NodeModel(getNodeHandle(), this);
 
+#if QT_VERSION_MAJOR >= 5
+	m_ui.nodeBox->setCurrentText("[auto]");
+#else
+	m_ui.nodeBox->setEditText("[auto]");
+#endif
+
 	connect(m_ui.nodeBox, SIGNAL(editTextChanged(QString)),
 		SLOT(setNamespace(QString))
 	);

--- a/src/gui/mon_gui.cpp
+++ b/src/gui/mon_gui.cpp
@@ -3,7 +3,11 @@
 
 #include "mon_gui.h"
 
+#if HAVE_PLUGINLIB_NEW_HEADERS
 #include <pluginlib/class_list_macros.hpp>
+#else
+#include <pluginlib/class_list_macros.h>
+#endif
 
 #include <QMenu>
 #include <QMessageBox>

--- a/src/gui/mon_gui.ui
+++ b/src/gui/mon_gui.ui
@@ -34,9 +34,6 @@
        <property name="editable">
         <bool>true</bool>
        </property>
-       <property name="currentText">
-        <string>[auto]</string>
-       </property>
        <property name="insertPolicy">
         <enum>QComboBox::NoInsert</enum>
        </property>

--- a/src/gui/rosmon_model.h
+++ b/src/gui/rosmon_model.h
@@ -5,6 +5,7 @@
 #define ROSMON_NODE_MODEL_H
 
 #include <QAbstractListModel>
+#include <QStringList>
 
 namespace rosmon
 {

--- a/src/monitor/monitor.cpp
+++ b/src/monitor/monitor.cpp
@@ -45,7 +45,11 @@ Monitor::Monitor(const launch::LaunchConfig::ConstPtr& config, const FDWatcher::
 		m_nodes.push_back(node);
 	}
 
+#if HAVE_STEADYTIMER
 	m_statTimer = m_nh.createSteadyTimer(
+#else
+	m_statTimer = m_nh.createWallTimer(
+#endif
 		ros::WallDuration(1.0),
 		boost::bind(&Monitor::updateStats, this)
 	);

--- a/src/monitor/monitor.h
+++ b/src/monitor/monitor.h
@@ -67,7 +67,12 @@ private:
 
 	bool m_ok;
 
+#if HAVE_STEADYTIMER
 	ros::SteadyTimer m_statTimer;
+#else
+	ros::WallTimer m_statTimer;
+#endif
+
 	std::map<int, ProcessInfo> m_processInfos;
 };
 


### PR DESCRIPTION
Adds some graceful fallbacks for Qt5 and roscpp features, so that rosmon compiles again under ROS Indigo.

See #9.