### PR TITLE
Skipping empty YAML files

### DIFF
--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -127,6 +127,17 @@ bool ParseContext::shouldSkip(TiXmlElement* e)
 	return false;
 }
 
+
+bool ParseContext::checkEmptyString(std::string str)
+{
+	for(char& c : str) {
+		if(!isspace(c) or c!='\n')
+			return false;
+	}
+	return true;
+}
+
+
 void ParseContext::setArg(const std::string& name, const std::string& value, bool override)
 {
 	auto it = m_args.find(name);
@@ -563,6 +574,13 @@ void LaunchConfig::parseROSParam(TiXmlElement* element, ParseContext ctx)
 			buffer << stream.rdbuf();
 
 			contents = buffer.str();
+
+			if(ctx.checkEmptyString(contents))
+			{
+				printf("File %s is empty, skipping...", fullFile.c_str());
+				return;
+			}
+
 		}
 		else
 			contents = element->GetText();

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -577,7 +577,7 @@ void LaunchConfig::parseROSParam(TiXmlElement* element, ParseContext ctx)
 
 			if(ctx.checkEmptyString(contents))
 			{
-				printf("File %s is empty, skipping...", fullFile.c_str());
+				printf("File %s is empty, skipping...\n", fullFile.c_str());
 				return;
 			}
 

--- a/src/launch/launch_config.h
+++ b/src/launch/launch_config.h
@@ -56,6 +56,8 @@ public:
 
 	bool parseBool(const std::string& input, int line);
 
+	bool checkEmptyString(std::string str);
+
 	void clearArguments()
 	{
 		m_args.clear();


### PR DESCRIPTION
Depending of the configuration I run my launch files, some yaml files may be empty and rosmon was unable to start because of that. I added a simple method to check if the yaml file is empty, if so, it prints a message and skips the file.