### PR TITLE
Simplify whitespace in <arg> tags

### DIFF
--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -769,12 +769,12 @@ void LaunchConfig::parseArgument(TiXmlElement* element, ParseContext& ctx)
 
 	if(value)
 	{
-		std::string fullValue = ctx.evaluate(value);
+		std::string fullValue = ctx.evaluate(simplifyWhitespace(value));
 		ctx.setArg(name, fullValue, true);
 	}
 	else if(def)
 	{
-		std::string fullValue = ctx.evaluate(def);
+		std::string fullValue = ctx.evaluate(simplifyWhitespace(def));
 		ctx.setArg(name, fullValue, false);
 	}
 	else

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -6,6 +6,7 @@
 
 #include <ros/package.h>
 
+#include <cctype>
 #include <fstream>
 
 #include <stdarg.h>
@@ -55,7 +56,7 @@ static std::string simplifyWhitespace(const std::string& input)
 	size_t i = 0;
 	for(; i < input.size(); ++i)
 	{
-		if(!isspace(i))
+		if(!std::isspace(static_cast<unsigned char>(input[i])))
 			break;
 	}
 
@@ -65,7 +66,7 @@ static std::string simplifyWhitespace(const std::string& input)
 	{
 		char c = input[i];
 
-		if(isspace(c))
+		if(std::isspace(static_cast<unsigned char>(c)))
 			in_space = true;
 		else
 		{


### PR DESCRIPTION
Example:

```
<launch>
  <arg name="test" value="abcde

fghij" />
</launch>
```

With this PR, rosmon produces `"abcde fghij"`, which is at least closer to roslaunch's `"abcde  fghij"` (two spaces!). It should at least fix issues with whitespace at begin/end of the value, such as #16.

Edit: the second string is not displayed by GitHub's markdown properly and there is no easy way to make it happen. Imagine two spaces between the words. Kind of ironic to hit this in an issue about whitespace simplification...