### PR TITLE
roslaunch/XML spec unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ if(CATKIN_ENABLE_TESTING)
 			test/xml/test_if_unless.cpp
 			test/xml/test_param.cpp
 			test/xml/test_rosparam.cpp
+			test/xml/test_subst.cpp
 		)
 		target_link_libraries(test_xml_loading
 			rosmon_launch_config

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,7 @@ add_executable(abort_really_long_executable
 if(CATKIN_ENABLE_TESTING)
 	# Integration tests
 	find_package(rostest REQUIRED)
-	add_rostest(test/basic.test)
+	add_rostest(test/basic.test DEPENDENCIES rosmon)
 
 	# XML parsing test suite
 	find_package(catch_ros)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,16 @@ if(${pluginlib_VERSION} VERSION_GREATER 1.11.1)
 	add_definitions(-DHAVE_PLUGINLIB_NEW_HEADERS=1)
 endif()
 
+# Are we building with test coverage instrumentation?
+set(BUILD_FOR_COVERAGE OFF CACHE BOOL "Build with coverage instrumentation?")
+if(BUILD_FOR_COVERAGE)
+	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+	else()
+		message(WARNING "Coverage build is only supported with clang")
+	endif()
+endif()
+
 add_executable(rosmon
 	src/main.cpp
 	src/launch/node.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,19 +67,28 @@ if(BUILD_FOR_COVERAGE)
 	endif()
 endif()
 
-add_executable(rosmon
-	src/main.cpp
+add_library(rosmon_launch_config
 	src/launch/node.cpp
 	src/launch/launch_config.cpp
 	src/launch/substitution.cpp
 	src/launch/substitution_python.cpp
+	src/package_registry.cpp
+)
+target_link_libraries(rosmon_launch_config
+	${catkin_LIBRARIES}
+	${TinyXML_LIBRARIES}
+	${Boost_LIBRARIES}
+	yaml-cpp
+)
+
+add_executable(rosmon
+	src/main.cpp
 	src/monitor/node_monitor.cpp
 	src/monitor/monitor.cpp
 	src/monitor/linux_process_info.cpp
 	src/ui.cpp
 	src/husl/husl.c
 	src/ros_interface.cpp
-	src/package_registry.cpp
 	src/fd_watcher.cpp
 	src/logger.cpp
 	src/terminal.cpp
@@ -91,6 +100,7 @@ target_link_libraries(rosmon
 	${Boost_LIBRARIES}
 	yaml-cpp
 	util
+	rosmon_launch_config
 )
 add_dependencies(rosmon
 	${PROJECT_NAME}_generate_messages_cpp
@@ -189,7 +199,7 @@ catkin_add_env_hooks(50-rosmon
 	DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks
 )
 
-install(TARGETS rosmon
+install(TARGETS rosmon rosmon_launch_config
 	LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 	RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ if(CATKIN_ENABLE_TESTING)
 		catch_add_test(test_xml_loading
 			test/xml/test_param.cpp
 			test/xml/test_if_unless.cpp
+			test/xml/test_basic.cpp
 		)
 		target_link_libraries(test_xml_loading
 			rosmon_launch_config

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,8 +189,25 @@ add_executable(abort_really_long_executable
 
 # Register unit tests
 if(CATKIN_ENABLE_TESTING)
+	# Integration tests
 	find_package(rostest REQUIRED)
 	add_rostest(test/basic.test)
+
+	# XML parsing test suite
+	find_package(catch_ros)
+	if(catch_ros_FOUND)
+		include_directories(${catch_ros_INCLUDE_DIRS})
+
+		catch_add_test(test_xml_loading
+			test/xml/test_param.cpp
+		)
+		target_link_libraries(test_xml_loading
+			rosmon_launch_config
+			${catch_ros_LIBRARIES}
+		)
+	else()
+		message(WARNING "Install catch_ros to enable XML unit tests")
+	endif()
 endif()
 
 # Version 1.4 (increment this comment to trigger a CMake update)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ if(CATKIN_ENABLE_TESTING)
 			test/xml/test_env.cpp
 			test/xml/test_basic.cpp
 			test/xml/test_if_unless.cpp
+			test/xml/test_node.cpp
 			test/xml/test_param.cpp
 			test/xml/test_rosparam.cpp
 			test/xml/test_subst.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,9 +199,10 @@ if(CATKIN_ENABLE_TESTING)
 		include_directories(${catch_ros_INCLUDE_DIRS})
 
 		catch_add_test(test_xml_loading
-			test/xml/test_param.cpp
-			test/xml/test_if_unless.cpp
 			test/xml/test_basic.cpp
+			test/xml/test_if_unless.cpp
+			test/xml/test_param.cpp
+			test/xml/test_rosparam.cpp
 		)
 		target_link_libraries(test_xml_loading
 			rosmon_launch_config

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ if(CATKIN_ENABLE_TESTING)
 			test/xml/test_env.cpp
 			test/xml/test_basic.cpp
 			test/xml/test_if_unless.cpp
+			test/xml/test_include.cpp
 			test/xml/test_node.cpp
 			test/xml/test_param.cpp
 			test/xml/test_rosparam.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,7 @@ if(CATKIN_ENABLE_TESTING)
 		include_directories(${catch_ros_INCLUDE_DIRS})
 
 		catch_add_test(test_xml_loading
+			test/xml/test_arg.cpp
 			test/xml/test_env.cpp
 			test/xml/test_basic.cpp
 			test/xml/test_if_unless.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,7 @@ if(CATKIN_ENABLE_TESTING)
 		include_directories(${catch_ros_INCLUDE_DIRS})
 
 		catch_add_test(test_xml_loading
+			test/xml/test_env.cpp
 			test/xml/test_basic.cpp
 			test/xml/test_if_unless.cpp
 			test/xml/test_param.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ if(CATKIN_ENABLE_TESTING)
 
 		catch_add_test(test_xml_loading
 			test/xml/test_param.cpp
+			test/xml/test_if_unless.cpp
 		)
 		target_link_libraries(test_xml_loading
 			rosmon_launch_config

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
 
 	<test_depend>python-rospkg</test_depend>
 	<test_depend>rostest</test_depend>
+	<test_depend>catch_ros</test_depend>
 
 	<export>
 		<rqt_gui plugin="${prefix}/rqt_plugin.xml" />

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -308,6 +308,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 	const char* required = element->Attribute("required");
 	const char* launchPrefix = element->Attribute("launch-prefix");
 	const char* coredumpsEnabled = element->Attribute("enable-coredumps");
+	const char* cwd = element->Attribute("cwd");
 
 	if(!name || !pkg || !type)
 	{
@@ -408,6 +409,9 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 
 	if(coredumpsEnabled)
 		node->setCoredumpsEnabled(ctx.parseBool(coredumpsEnabled, element->Row()));
+
+	if(cwd)
+		node->setWorkingDirectory(ctx.evaluate(cwd));
 
 	m_nodes.push_back(node);
 }

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -430,6 +430,14 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 		);
 	}
 
+	int numCommands = (value ? 1 : 0) + (command ? 1 : 0) + (textfile ? 1 : 0) + (binfile ? 1 : 0);
+	if(numCommands > 1) // == 0 is checked below, don't duplicate.
+	{
+		throw error("File %s:%d: <param> tags need exactly one of value=, command=, textfile=, binfile= attributes.",
+			filename.c_str(), line
+		);
+	}
+
 	std::string fullName = ctx.evaluate(name);
 
 	// Expand relative paths

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -937,9 +937,17 @@ void LaunchConfig::parseInclude(TiXmlElement* element, ParseContext ctx)
 	const char* file = element->Attribute("file");
 	const char* ns = element->Attribute("ns");
 	const char* passAllArgs = element->Attribute("pass_all_args");
+	const char* clearParams = element->Attribute("clear_params");
 
 	if(!file)
 		throw error("%s:%d: file attribute is mandatory", ctx.filename().c_str(), element->Row());
+
+	if(clearParams && ctx.parseBool(clearParams, element->Row()))
+	{
+		throw error("%s:%d: <include clear_params=\"true\" /> is not supported and probably a bad idea.",
+			ctx.filename().c_str(), element->Row()
+		);
+	}
 
 	std::string fullFile = ctx.evaluate(file);
 

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -194,16 +194,45 @@ void LaunchConfig::parse(const std::string& filename, bool onlyArguments)
 	parse(document.RootElement(), &m_rootContext, onlyArguments);
 
 	// Parse top-level rosmon-specific attributes
-	const char* name = document.RootElement()->Attribute("rosmon-name");
-	if(name)
-		m_rosmonNodeName = name;
-
-	const char* windowTitle = document.RootElement()->Attribute("rosmon-window-title");
-	if(windowTitle)
-		m_windowTitle = windowTitle;
+	parseTopLevelAttributes(document.RootElement());
 
 	if(!onlyArguments)
 		printf("Loaded launch file in %fs\n", (ros::WallTime::now() - start).toSec());
+}
+
+void LaunchConfig::parseString(const std::string& input, bool onlyArguments)
+{
+	TiXmlDocument document;
+
+	TiXmlBase::SetCondenseWhiteSpace(false);
+
+	document.Parse(input.c_str());
+
+	if(document.Error())
+	{
+		throw error("Could not parse string input: %s\n", document.ErrorDesc());
+	}
+
+	ros::WallTime start = ros::WallTime::now();
+	m_rootContext.setFilename("[string]");
+	parse(document.RootElement(), &m_rootContext, onlyArguments);
+
+	// Parse top-level rosmon-specific attributes
+	parseTopLevelAttributes(document.RootElement());
+
+	if(!onlyArguments)
+		printf("Loaded launch file in %fs\n", (ros::WallTime::now() - start).toSec());
+}
+
+void LaunchConfig::parseTopLevelAttributes(TiXmlElement* element)
+{
+	const char* name = element->Attribute("rosmon-name");
+	if(name)
+		m_rosmonNodeName = name;
+
+	const char* windowTitle = element->Attribute("rosmon-window-title");
+	if(windowTitle)
+		m_windowTitle = windowTitle;
 }
 
 void LaunchConfig::parse(TiXmlElement* element, ParseContext* ctx, bool onlyArguments)

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -328,6 +328,20 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 		ctx.evaluate(name), ctx.evaluate(pkg), ctx.evaluate(type)
 	);
 
+	// Check name uniqueness
+	{
+		auto it = std::find_if(m_nodes.begin(), m_nodes.end(), [&](const Node::Ptr& n) {
+			return n->name() == node->name();
+		});
+
+		if(it != m_nodes.end())
+		{
+			throw error("%s:%d: node name '%s' is not unique",
+				ctx.filename().c_str(), element->Row(), node->name().c_str()
+			);
+		}
+	}
+
 	if(args)
 		node->addExtraArguments(ctx.evaluate(args));
 

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -331,7 +331,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 	// Check name uniqueness
 	{
 		auto it = std::find_if(m_nodes.begin(), m_nodes.end(), [&](const Node::Ptr& n) {
-			return n->name() == node->name();
+			return n->namespaceString() == fullNamespace && n->name() == node->name();
 		});
 
 		if(it != m_nodes.end())

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -309,6 +309,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 	const char* launchPrefix = element->Attribute("launch-prefix");
 	const char* coredumpsEnabled = element->Attribute("enable-coredumps");
 	const char* cwd = element->Attribute("cwd");
+	const char* clearParams = element->Attribute("clear_params");
 
 	if(!name || !pkg || !type)
 	{
@@ -412,6 +413,9 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 
 	if(cwd)
 		node->setWorkingDirectory(ctx.evaluate(cwd));
+
+	if(clearParams)
+		node->setClearParams(ctx.parseBool(clearParams, element->Row()));
 
 	m_nodes.push_back(node);
 }

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -121,10 +121,16 @@ bool ParseContext::parseBool(const std::string& value, int line)
 {
 	std::string expansion = evaluate(value);
 
-	if(expansion == "1" || expansion == "true")
+	// We are lenient here and accept the pythonic forms "True" and "False"
+	// as well, since roslaunch seems to do the same. Even the roslaunch/XML
+	// spec mentions True/False in the examples, even though they are not
+	// valid options for if/unless and other boolean attributes...
+	// http://wiki.ros.org/roslaunch/XML/rosparam
+
+	if(expansion == "1" || expansion == "true" || expansion == "True")
 		return true;
 
-	if(expansion == "0" || expansion == "false")
+	if(expansion == "0" || expansion == "false" || expansion == "False")
 		return false;
 
 	throw error("%s:%d: Unknown truth value '%s'", filename().c_str(), line, expansion.c_str());
@@ -754,7 +760,7 @@ void LaunchConfig::parseROSParam(TiXmlElement* element, ParseContext ctx)
 			return;
 
 		const char* subst_value = element->Attribute("subst_value");
-		if(subst_value && strcmp(subst_value, "true") == 0)
+		if(subst_value && ctx.parseBool(subst_value, element->Row()))
 			contents = ctx.evaluate(contents, false);
 
 		YAML::Node n;

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -12,6 +12,8 @@
 #include <cstdio>
 #include <fstream>
 
+#include <sys/wait.h>
+
 #include <boost/regex.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>
@@ -590,6 +592,17 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 				}
 
 				close(pipe_fd[0]);
+
+				int status = 0;
+				if(waitpid(pid, &status, 0) < 0)
+					throw error("Could not waitpid(): %s", strerror(errno));
+
+				if(!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+				{
+					throw error("%s:%d: <param> command failed (exit status %d)",
+						filename.c_str(), line, status
+					);
+				}
 
 				return buffer.str();
 			}

--- a/src/launch/launch_config.h
+++ b/src/launch/launch_config.h
@@ -144,6 +144,7 @@ private:
 
 	void loadYAMLParams(const YAML::Node& n, const std::string& prefix);
 
+	XmlRpc::XmlRpcValue paramToXmlRpc(const std::string& filename, int line, const std::string& value, const std::string& type = "");
 	XmlRpc::XmlRpcValue yamlToXmlRpc(const YAML::Node& n);
 
 	ParseContext m_rootContext;

--- a/src/launch/launch_config.h
+++ b/src/launch/launch_config.h
@@ -150,9 +150,19 @@ private:
 	ParseContext m_rootContext;
 
 	std::vector<Node::Ptr> m_nodes;
-	typedef std::future<XmlRpc::XmlRpcValue> ParameterFuture;
-	std::map<std::string, XmlRpc::XmlRpcValue> m_params;
+
+	using ParameterList = std::map<std::string, XmlRpc::XmlRpcValue>;
+	using ParameterFuture = std::future<XmlRpc::XmlRpcValue>;
+
+	struct YAMLResult
+	{
+		std::string name;
+		YAML::Node yaml;
+	};
+
+	ParameterList m_params;
 	std::map<std::string, ParameterFuture> m_paramJobs;
+	std::vector<std::future<YAMLResult>> m_yamlParamJobs;
 
 	std::map<std::string, std::string> m_anonNames;
 	std::mt19937_64 m_anonGen;

--- a/src/launch/launch_config.h
+++ b/src/launch/launch_config.h
@@ -111,6 +111,7 @@ public:
 	void setArgument(const std::string& name, const std::string& value);
 
 	void parse(const std::string& filename, bool onlyArguments = false);
+	void parseString(const std::string& input, bool onlyArguments = false);
 
 	void evaluateParameters();
 
@@ -131,6 +132,8 @@ public:
 	std::string windowTitle() const
 	{ return m_windowTitle; }
 private:
+	void parseTopLevelAttributes(TiXmlElement* element);
+
 	void parse(TiXmlElement* element, ParseContext* ctx, bool onlyArguments = false);
 	void parseNode(TiXmlElement* element, ParseContext ctx);
 	void parseParam(TiXmlElement* element, ParseContext ctx);

--- a/src/launch/node.cpp
+++ b/src/launch/node.cpp
@@ -42,6 +42,7 @@ Node::Node(std::string name, std::string package, std::string type)
 
  , m_required(false)
  , m_coredumpsEnabled(true)
+ , m_clearParams(false)
 {
 	m_executable = PackageRegistry::getExecutable(m_package, m_type);
 }
@@ -134,6 +135,11 @@ void Node::setCoredumpsEnabled(bool on)
 void Node::setWorkingDirectory(const std::string& cwd)
 {
 	m_workingDirectory = cwd;
+}
+
+void Node::setClearParams(bool on)
+{
+	m_clearParams = on;
 }
 
 }

--- a/src/launch/node.cpp
+++ b/src/launch/node.cpp
@@ -131,6 +131,11 @@ void Node::setCoredumpsEnabled(bool on)
 	m_coredumpsEnabled = on;
 }
 
+void Node::setWorkingDirectory(const std::string& cwd)
+{
+	m_workingDirectory = cwd;
+}
+
 }
 
 }

--- a/src/launch/node.h
+++ b/src/launch/node.h
@@ -36,6 +36,8 @@ public:
 
 	void setLaunchPrefix(const std::string& launchPrefix);
 
+	void setWorkingDirectory(const std::string& workingDirectory);
+
 	std::string name() const
 	{ return m_name; }
 
@@ -76,6 +78,9 @@ public:
 
 	bool coredumpsEnabled() const
 	{ return m_coredumpsEnabled; }
+
+	std::string workingDirectory() const
+	{ return m_workingDirectory; }
 private:
 	std::string m_name;
 	std::string m_package;
@@ -98,6 +103,8 @@ private:
 	std::vector<std::string> m_launchPrefix;
 
 	bool m_coredumpsEnabled;
+
+	std::string m_workingDirectory;
 };
 
 }

--- a/src/launch/node.h
+++ b/src/launch/node.h
@@ -38,6 +38,8 @@ public:
 
 	void setWorkingDirectory(const std::string& workingDirectory);
 
+	void setClearParams(bool on);
+
 	std::string name() const
 	{ return m_name; }
 
@@ -81,6 +83,9 @@ public:
 
 	std::string workingDirectory() const
 	{ return m_workingDirectory; }
+
+	bool clearParams() const
+	{ return m_clearParams; }
 private:
 	std::string m_name;
 	std::string m_package;
@@ -105,6 +110,8 @@ private:
 	bool m_coredumpsEnabled;
 
 	std::string m_workingDirectory;
+
+	bool m_clearParams;
 };
 
 }

--- a/src/launch/substitution.h
+++ b/src/launch/substitution.h
@@ -24,7 +24,7 @@ public:
 	virtual ~SubstitutionException() throw()
 	{}
 
-	virtual const char* what() const noexcept
+	virtual const char* what() const noexcept override
 	{ return m_msg.c_str(); }
 private:
 	std::string m_msg;

--- a/src/launch/substitution_python.cpp
+++ b/src/launch/substitution_python.cpp
@@ -174,28 +174,29 @@ std::string evaluatePython(const std::string& input, ParseContext& context)
 		throw error("%s", ss.str().c_str());
 	}
 
-	py::extract<std::string> asString(result);
-	if(asString.check())
-	{
-		return asString();
-	}
+	if(PyString_Check(result.ptr()))
+		return py::extract<std::string>(result);
 
-	py::extract<bool> asBool(result);
-	if(asBool.check())
+	if(PyBool_Check(result.ptr()))
 	{
-		if(asBool())
+		if(py::extract<bool>(result))
 			return "true";
 		else
 			return "false";
 	}
 
-	py::extract<int> asInt(result);
-	if(asInt.check())
-		return std::to_string(asInt());
+	if(PyInt_Check(result.ptr()))
+	{
+		return std::to_string(py::extract<int>(result));
+	}
 
-	py::extract<float> asFloat(result);
-	if(asFloat.check())
-		return boost::lexical_cast<std::string>(asFloat()); // to_string has low precision
+	if(PyFloat_Check(result.ptr()))
+	{
+		// std::to_string has low precision here, so use boost::lexical_cast
+		return boost::lexical_cast<std::string>(
+			py::extract<float>(result)()
+		);
+	}
 
 	throw error("$(eval '%s'): Got unknown python return type", input.c_str());
 }

--- a/src/monitor/node_monitor.h
+++ b/src/monitor/node_monitor.h
@@ -211,6 +211,7 @@ private:
 	uint64_t m_memory = 0;
 
 	std::string m_processWorkingDirectory;
+	bool m_processWorkingDirectoryCreated = false;
 };
 
 }

--- a/test/textfile.txt
+++ b/test/textfile.txt
@@ -1,0 +1,1 @@
+hello_world

--- a/test/xml/param_utils.h
+++ b/test/xml/param_utils.h
@@ -102,4 +102,18 @@ void checkTypedParam(const ParameterMap& parameters, const std::string& name, Xm
 	REQUIRE(static_cast<T>(value) == expected);
 }
 
+template<class T>
+T getTypedParam(const ParameterMap& parameters, const std::string& name)
+{
+	CAPTURE(parameters);
+	CAPTURE(name);
+
+	auto it = parameters.find(name);
+	REQUIRE(it != parameters.end());
+
+	XmlRpc::XmlRpcValue value = it->second;
+
+	return static_cast<T>(value);
+}
+
 #endif

--- a/test/xml/param_utils.h
+++ b/test/xml/param_utils.h
@@ -1,0 +1,82 @@
+// Utilities for checking params
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#ifndef PARAM_UTILS_H
+#define PARAM_UTILS_H
+
+#include <catch_ros/catch.hpp>
+
+#include <XmlRpcValue.h>
+
+typedef std::map<std::string, XmlRpc::XmlRpcValue> ParameterMap;
+
+namespace Catch
+{
+	template<>
+	struct StringMaker<XmlRpc::XmlRpcValue>
+	{
+		static std::string convert(const XmlRpc::XmlRpcValue& value)
+		{
+			// We need a copy, since the cast operators don't work on const
+			// refs *sigh*
+			XmlRpc::XmlRpcValue copy = value;
+
+			std::stringstream ss;
+			ss << "XmlRpc";
+			switch(value.getType())
+			{
+				case XmlRpc::XmlRpcValue::TypeInt:
+					ss << "<int>(" << static_cast<int>(copy) << ")";
+					break;
+				case XmlRpc::XmlRpcValue::TypeBoolean:
+					ss << "<bool>(" << static_cast<bool>(copy) << ")";
+					break;
+				case XmlRpc::XmlRpcValue::TypeString:
+					ss << "<string>('" << static_cast<std::string>(copy) << "')";
+					break;
+				case XmlRpc::XmlRpcValue::TypeDouble:
+					ss << "<double>(" << static_cast<double>(copy) << ")";
+					break;
+				default:
+					ss << "<unknown>()";
+					break;
+			}
+
+			return ss.str();
+		}
+	};
+
+	template<>
+	struct StringMaker<ParameterMap>
+	{
+		static std::string convert(const ParameterMap& value)
+		{
+			std::stringstream ss;
+			ss << "{";
+			for(auto& param : value)
+			{
+				ss << "\"" << param.first << "\"=" << StringMaker<XmlRpc::XmlRpcValue>::convert(param.second) << ", ";
+			}
+			ss << "}";
+
+			return ss.str();
+		}
+	};
+}
+
+template<class T>
+void checkTypedParam(const ParameterMap& parameters, const std::string& name, XmlRpc::XmlRpcValue::Type expectedType, T expected)
+{
+	CAPTURE(parameters);
+	CAPTURE(name);
+
+	auto it = parameters.find(name);
+	REQUIRE(it != parameters.end());
+
+	XmlRpc::XmlRpcValue value = it->second;
+
+	REQUIRE(value.getType() == expectedType);
+	REQUIRE(static_cast<T>(value) == expected);
+}
+
+#endif

--- a/test/xml/param_utils.h
+++ b/test/xml/param_utils.h
@@ -13,6 +13,27 @@ typedef std::map<std::string, XmlRpc::XmlRpcValue> ParameterMap;
 namespace Catch
 {
 	template<>
+	struct StringMaker<XmlRpc::XmlRpcValue::Type>
+	{
+		static std::string convert(const XmlRpc::XmlRpcValue::Type& value)
+		{
+			switch(value)
+			{
+				case XmlRpc::XmlRpcValue::TypeInvalid: return "TypeInvalid";
+				case XmlRpc::XmlRpcValue::TypeBoolean: return "TypeBoolean";
+				case XmlRpc::XmlRpcValue::TypeInt: return "TypeInt";
+				case XmlRpc::XmlRpcValue::TypeDouble: return "TypeDouble";
+				case XmlRpc::XmlRpcValue::TypeString: return "TypeString";
+				case XmlRpc::XmlRpcValue::TypeDateTime: return "TypeDateTime";
+				case XmlRpc::XmlRpcValue::TypeBase64: return "TypeBase64";
+				case XmlRpc::XmlRpcValue::TypeArray: return "TypeArray";
+				case XmlRpc::XmlRpcValue::TypeStruct: return "TypeStruct";
+				default: return "unknown type";
+			}
+		}
+	};
+
+	template<>
 	struct StringMaker<XmlRpc::XmlRpcValue>
 	{
 		static std::string convert(const XmlRpc::XmlRpcValue& value)
@@ -38,7 +59,9 @@ namespace Catch
 					ss << "<double>(" << static_cast<double>(copy) << ")";
 					break;
 				default:
-					ss << "<unknown>()";
+					ss << "<"
+						<< StringMaker<XmlRpc::XmlRpcValue::Type>::convert(value.getType())
+						<< ">(?)";
 					break;
 			}
 

--- a/test/xml/test_arg.cpp
+++ b/test/xml/test_arg.cpp
@@ -1,0 +1,78 @@
+// Unit tests for arg tags
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include <catch_ros/catch.hpp>
+
+#include "../../src/launch/launch_config.h"
+
+#include "param_utils.h"
+
+using namespace rosmon::launch;
+
+TEST_CASE("arg basic", "[arg]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<arg name="arg1" value="hello world" />
+			<arg name="arg2" default="hello world" />
+
+			<param name="arg1" value="$(arg arg1)" />
+			<param name="arg2" value="$(arg arg2)" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto params = config.parameters();
+
+	CHECK(getTypedParam<std::string>(params, "/arg1") == "hello world");
+	CHECK(getTypedParam<std::string>(params, "/arg2") == "hello world");
+}
+
+TEST_CASE("arg from external", "[arg]")
+{
+	LaunchConfig config;
+
+	config.setArgument("arg1", "test");
+	config.setArgument("arg2", "test");
+
+	config.parseString(R"EOF(
+		<launch>
+			<arg name="arg1" />
+			<arg name="arg2" default="hello world" />
+
+			<param name="arg1" value="$(arg arg1)" />
+			<param name="arg2" value="$(arg arg2)" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto params = config.parameters();
+
+	CHECK(getTypedParam<std::string>(params, "/arg1") == "test");
+	CHECK(getTypedParam<std::string>(params, "/arg2") == "test");
+}
+
+TEST_CASE("arg unset", "[arg]")
+{
+	REQUIRE_THROWS_AS(
+		LaunchConfig().parseString(R"EOF(
+			<launch>
+				<param name="test" value="$(arg arg1)" />
+			</launch>
+		)EOF"),
+		LaunchConfig::ParseException
+	);
+
+	REQUIRE_THROWS_AS(
+		LaunchConfig().parseString(R"EOF(
+			<launch>
+				<arg name="arg1" />
+				<param name="test" value="$(arg arg1)" />
+			</launch>
+		)EOF"),
+		LaunchConfig::ParseException
+	);
+}

--- a/test/xml/test_basic.cpp
+++ b/test/xml/test_basic.cpp
@@ -1,0 +1,43 @@
+// Unit tests for basic loading
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include <catch_ros/catch.hpp>
+
+#include "../../src/launch/launch_config.h"
+
+#include "param_utils.h"
+
+using namespace rosmon::launch;
+
+TEST_CASE("basic", "[basic]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+		</launch>
+	)EOF");
+}
+
+TEST_CASE("basic: invalid XML", "[basic]")
+{
+	LaunchConfig config;
+	REQUIRE_THROWS_AS(
+		config.parseString(R"EOF(
+			<launch><abc>
+			</launch>
+		)EOF"),
+		LaunchConfig::ParseException
+	);
+}
+
+TEST_CASE("basic: top-level attributes", "[basic]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch rosmon-name="my_name" rosmon-window-title="my_title">
+		</launch>
+	)EOF");
+
+	CHECK(config.rosmonNodeName() == "my_name");
+	CHECK(config.windowTitle() == "my_title");
+}

--- a/test/xml/test_env.cpp
+++ b/test/xml/test_env.cpp
@@ -1,0 +1,36 @@
+// Unit tests for env tags
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include <catch_ros/catch.hpp>
+
+#include "../../src/launch/launch_config.h"
+
+#include "param_utils.h"
+
+using namespace rosmon::launch;
+
+TEST_CASE("env basic", "[env]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<env name="test" value="hello world" />
+
+			<node name="test_node" pkg="rosmon" type="abort" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto nodes = config.nodes();
+	CAPTURE(nodes);
+
+	REQUIRE(nodes.size() == 1);
+
+	auto node = nodes.at(0);
+
+	auto env = node->extraEnvironment();
+	CAPTURE(env);
+
+	CHECK(env.at("test") == "hello world");
+}

--- a/test/xml/test_if_unless.cpp
+++ b/test/xml/test_if_unless.cpp
@@ -17,6 +17,9 @@ TEST_CASE("if/unless basic", "[if_unless]")
 			<param if="false" name="test_if" value="hello" />
 			<param if="true" name="test_if" value="world" />
 
+			<param if="1" name="test_if_number" value="hello" />
+			<param if="0" name="test_if_number" value="world" />
+
 			<param unless="false" name="test_unless" value="hello" />
 			<param unless="true" name="test_unless" value="world" />
 		</launch>
@@ -28,6 +31,7 @@ TEST_CASE("if/unless basic", "[if_unless]")
 
 	auto& params = config.parameters();
 	checkTypedParam<std::string>(params, "/test_if", XmlRpc::XmlRpcValue::TypeString, "world");
+	checkTypedParam<std::string>(params, "/test_if_number", XmlRpc::XmlRpcValue::TypeString, "hello");
 	checkTypedParam<std::string>(params, "/test_unless", XmlRpc::XmlRpcValue::TypeString, "hello");
 }
 

--- a/test/xml/test_if_unless.cpp
+++ b/test/xml/test_if_unless.cpp
@@ -1,0 +1,47 @@
+// Unit tests for if/unless attributes
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include <catch_ros/catch.hpp>
+
+#include "../../src/launch/launch_config.h"
+
+#include "param_utils.h"
+
+using namespace rosmon::launch;
+
+TEST_CASE("if/unless basic", "[if_unless]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<param if="false" name="test_if" value="hello" />
+			<param if="true" name="test_if" value="world" />
+
+			<param unless="false" name="test_unless" value="hello" />
+			<param unless="true" name="test_unless" value="world" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	CAPTURE(config.parameters());
+
+	auto& params = config.parameters();
+	checkTypedParam<std::string>(params, "/test_if", XmlRpc::XmlRpcValue::TypeString, "world");
+	checkTypedParam<std::string>(params, "/test_unless", XmlRpc::XmlRpcValue::TypeString, "hello");
+}
+
+TEST_CASE("if/unless invalid", "[if_unless]")
+{
+	using Catch::Matchers::Contains;
+
+	REQUIRE_THROWS_WITH(
+		LaunchConfig().parseString(R"EOF(<launch><param if="true" unless="true" name="test" value="test" /></launch>)EOF"),
+		Contains("if") && Contains("unless")
+	);
+
+	REQUIRE_THROWS_AS(
+		LaunchConfig().parseString(R"EOF(<launch><param if="unknown_value" name="test" value="test" /></launch>)EOF"),
+		LaunchConfig::ParseException
+	);
+}

--- a/test/xml/test_include.cpp
+++ b/test/xml/test_include.cpp
@@ -1,0 +1,48 @@
+// Unit tests for include tags
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include <catch_ros/catch.hpp>
+
+#include "../../src/launch/launch_config.h"
+
+#include "param_utils.h"
+
+using namespace rosmon::launch;
+
+TEST_CASE("include basic", "[include]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<arg name="test_argument" value="hello" />
+
+			<include file="$(find rosmon)/test/basic_sub.launch">
+				<arg name="test_argument" value="$(arg test_argument)" />
+			</include>
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto params = config.parameters();
+
+	CHECK(getTypedParam<std::string>(params, "/test_argument") == "hello");
+}
+
+TEST_CASE("include pass_all", "[include]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<arg name="test_argument" value="hello" />
+
+			<include file="$(find rosmon)/test/basic_sub.launch" pass_all_args="true" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto params = config.parameters();
+
+	CHECK(getTypedParam<std::string>(params, "/test_argument") == "hello");
+}

--- a/test/xml/test_node.cpp
+++ b/test/xml/test_node.cpp
@@ -214,12 +214,14 @@ TEST_CASE("node ns", "[node]")
 	}
 }
 
-TEST_CASE("node clear_params", "[node][!mayfail]")
+TEST_CASE("node clear_params", "[node]")
 {
 	LaunchConfig config;
 	config.parseString(R"EOF(
 		<launch>
-			<node name="test_node" pkg="rosmon" type="abort" clear_params="true" />
+			<node name="test_node_on" pkg="rosmon" type="abort" clear_params="true" />
+			<node name="test_node_off" pkg="rosmon" type="abort" clear_params="false" />
+			<node name="test_node_def" pkg="rosmon" type="abort" />
 		</launch>
 	)EOF");
 
@@ -228,9 +230,9 @@ TEST_CASE("node clear_params", "[node][!mayfail]")
 	auto nodes = config.nodes();
 	CAPTURE(nodes);
 
-	auto node = getNode(nodes, "test_node");
-
-	FAIL("not implemented");
+	CHECK(getNode(nodes, "test_node_on")->clearParams() == true);
+	CHECK(getNode(nodes, "test_node_off")->clearParams() == false);
+	CHECK(getNode(nodes, "test_node_def")->clearParams() == false);
 }
 
 TEST_CASE("node cwd", "[node]")

--- a/test/xml/test_node.cpp
+++ b/test/xml/test_node.cpp
@@ -264,3 +264,24 @@ TEST_CASE("node launch-prefix", "[node]")
 	CHECK(prefix[2] == "command");
 	CHECK(prefix[3] == "is:");
 }
+
+// rosmon extensions
+
+TEST_CASE("node enable-coredumps", "[node]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<node name="test_node_on" pkg="rosmon" type="abort" enable-coredumps="true" />
+			<node name="test_node_off" pkg="rosmon" type="abort" enable-coredumps="false" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto nodes = config.nodes();
+	CAPTURE(nodes);
+
+	CHECK(getNode(nodes, "test_node_on")->coredumpsEnabled() == true);
+	CHECK(getNode(nodes, "test_node_off")->coredumpsEnabled() == false);
+}

--- a/test/xml/test_node.cpp
+++ b/test/xml/test_node.cpp
@@ -220,7 +220,7 @@ TEST_CASE("node clear_params", "[node][!mayfail]")
 	FAIL("not implemented");
 }
 
-TEST_CASE("node cwd", "[node][!mayfail]")
+TEST_CASE("node cwd", "[node]")
 {
 	LaunchConfig config;
 	config.parseString(R"EOF(
@@ -236,7 +236,7 @@ TEST_CASE("node cwd", "[node][!mayfail]")
 
 	auto node = getNode(nodes, "test_node");
 
-	FAIL("not implemented");
+	CHECK(node->workingDirectory() == "/my_cwd/");
 }
 
 TEST_CASE("node launch-prefix", "[node]")

--- a/test/xml/test_node.cpp
+++ b/test/xml/test_node.cpp
@@ -1,0 +1,266 @@
+// Unit tests for node tags
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include <catch_ros/catch.hpp>
+
+#include "../../src/launch/launch_config.h"
+
+#include "param_utils.h"
+
+using namespace rosmon::launch;
+
+namespace Catch
+{
+	template<>
+	struct StringMaker<Node::Ptr>
+	{
+		static std::string convert(const Node::Ptr& node)
+		{
+			if(node)
+				return "NodePtr(name='" + node->name() + "', namespace='" + node->namespaceString() + "')";
+			else
+				return "NodePtr()";
+		}
+	};
+
+	template<>
+	struct StringMaker<std::vector<Node::Ptr>>
+	{
+		static std::string convert(const std::vector<Node::Ptr>& nodes)
+		{
+			std::stringstream ss;
+			ss << "{ ";
+			for(auto& n : nodes)
+				ss << StringMaker<Node::Ptr>::convert(n) << ", ";
+			ss << "}";
+
+			return ss.str();
+		}
+	};
+}
+
+Node::Ptr getNode(const std::vector<Node::Ptr>& nodes, const std::string& name, const std::string& namespaceString="")
+{
+	Node::Ptr ret;
+
+	INFO("Looking for node '" << name << "' in namespace '" << namespaceString << "'");
+
+	for(auto& node : nodes)
+	{
+		if(node->namespaceString() != namespaceString)
+			continue;
+
+		if(node->name() == name)
+		{
+			REQUIRE(!ret);
+			ret = node;
+		}
+	}
+
+	REQUIRE(ret);
+	return ret;
+}
+
+TEST_CASE("node basic", "[node]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<node name="test_node" pkg="rosmon" type="abort" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto nodes = config.nodes();
+	CAPTURE(nodes);
+
+	REQUIRE(nodes.size() == 1);
+
+	auto node = getNode(nodes, "test_node");
+
+	CHECK(node->name() == "test_node");
+	CHECK(node->package() == "rosmon");
+	CHECK(node->type() == "abort");
+}
+
+TEST_CASE("node invalid", "[node]")
+{
+	REQUIRE_THROWS_AS(
+		LaunchConfig().parseString(R"EOF(
+			<launch>
+				<node name="test_node" />
+			</launch>
+		)EOF"),
+		LaunchConfig::ParseException
+	);
+}
+
+TEST_CASE("node args", "[node]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<node name="test_node" pkg="rosmon" type="abort" args="arg1 arg2 'long arg'" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto nodes = config.nodes();
+	CAPTURE(nodes);
+
+	REQUIRE(nodes.size() == 1);
+
+	auto node = getNode(nodes, "test_node");
+
+	auto args = node->extraArguments();
+
+	REQUIRE(args.size() == 3);
+	CHECK(args[0] == "arg1");
+	CHECK(args[1] == "arg2");
+	CHECK(args[2] == "long arg");
+}
+
+TEST_CASE("node respawn", "[node]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<node name="test_node" pkg="rosmon" type="abort" respawn="true" respawn_delay="10" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto nodes = config.nodes();
+	CAPTURE(nodes);
+
+	REQUIRE(nodes.size() == 1);
+
+	auto node = getNode(nodes, "test_node");
+
+	CHECK(node->respawn());
+	CHECK(node->respawnDelay().toSec() == Approx(10.0));
+}
+
+TEST_CASE("node required", "[node]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<node name="test_node" pkg="rosmon" type="abort" required="true" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto nodes = config.nodes();
+	CAPTURE(nodes);
+
+	REQUIRE(nodes.size() == 1);
+
+	auto node = getNode(nodes, "test_node");
+
+	CHECK(node->required());
+}
+
+TEST_CASE("node ns", "[node]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<node name="test_node" pkg="rosmon" type="abort" ns="namespace" />
+
+			<group ns="ns1">
+				<node name="test_node" pkg="rosmon" type="abort" />
+
+				<node name="test_node" pkg="rosmon" type="abort" ns="namespace" />
+			</group>
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto nodes = config.nodes();
+	CAPTURE(nodes);
+
+	REQUIRE(nodes.size() == 3);
+
+	{
+		auto node = getNode(nodes, "test_node", "/namespace");
+		CHECK(node->namespaceString() == "/namespace");
+	}
+	{
+		auto node = getNode(nodes, "test_node", "/ns1");
+		CHECK(node->namespaceString() == "/ns1");
+	}
+	{
+		auto node = getNode(nodes, "test_node", "/ns1/namespace");
+		CHECK(node->namespaceString() == "/ns1/namespace");
+	}
+}
+
+TEST_CASE("node clear_params", "[node][!mayfail]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<node name="test_node" pkg="rosmon" type="abort" clear_params="true" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto nodes = config.nodes();
+	CAPTURE(nodes);
+
+	auto node = getNode(nodes, "test_node");
+
+	FAIL("not implemented");
+}
+
+TEST_CASE("node cwd", "[node][!mayfail]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<node name="test_node" pkg="rosmon" type="abort" cwd="/my_cwd/" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto nodes = config.nodes();
+	CAPTURE(nodes);
+
+	auto node = getNode(nodes, "test_node");
+
+	FAIL("not implemented");
+}
+
+TEST_CASE("node launch-prefix", "[node]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<node name="test_node" pkg="rosmon" type="abort" launch-prefix="echo my command is:" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto nodes = config.nodes();
+	CAPTURE(nodes);
+
+	auto node = getNode(nodes, "test_node");
+
+	auto prefix = node->launchPrefix();
+	CAPTURE(prefix);
+
+	REQUIRE(prefix.size() == 4);
+	CHECK(prefix[0] == "echo");
+	CHECK(prefix[1] == "my");
+	CHECK(prefix[2] == "command");
+	CHECK(prefix[3] == "is:");
+}

--- a/test/xml/test_node.cpp
+++ b/test/xml/test_node.cpp
@@ -5,6 +5,8 @@
 
 #include "../../src/launch/launch_config.h"
 
+#include <boost/filesystem.hpp>
+
 #include "param_utils.h"
 
 using namespace rosmon::launch;
@@ -95,6 +97,14 @@ TEST_CASE("node basic", "[node]")
 	CHECK(node->name() == "test_node");
 	CHECK(node->package() == "rosmon");
 	CHECK(node->type() == "abort");
+
+	{
+		namespace fs = boost::filesystem;
+
+		fs::path executable = node->executable();
+		CAPTURE(executable.string());
+		CHECK((fs::status(executable).permissions() & fs::owner_exe));
+	}
 }
 
 TEST_CASE("node invalid", "[node]")

--- a/test/xml/test_param.cpp
+++ b/test/xml/test_param.cpp
@@ -1,65 +1,13 @@
+// Unit tests for <param> tags
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
 
 #include <catch_ros/catch.hpp>
 
 #include "../../src/launch/launch_config.h"
 
+#include "param_utils.h"
+
 using namespace rosmon::launch;
-
-typedef std::map<std::string, XmlRpc::XmlRpcValue> ParameterMap;
-
-namespace Catch
-{
-	template<>
-	struct StringMaker<XmlRpc::XmlRpcValue>
-	{
-		static std::string convert(const XmlRpc::XmlRpcValue& value)
-		{
-			// We need a copy, since the cast operators don't work on const
-			// refs *sigh*
-			XmlRpc::XmlRpcValue copy = value;
-
-			std::stringstream ss;
-			ss << "XmlRpc";
-			switch(value.getType())
-			{
-				case XmlRpc::XmlRpcValue::TypeInt:
-					ss << "<int>(" << static_cast<int>(copy) << ")";
-					break;
-				case XmlRpc::XmlRpcValue::TypeBoolean:
-					ss << "<bool>(" << static_cast<bool>(copy) << ")";
-					break;
-				case XmlRpc::XmlRpcValue::TypeString:
-					ss << "<string>('" << static_cast<std::string>(copy) << "')";
-					break;
-				case XmlRpc::XmlRpcValue::TypeDouble:
-					ss << "<double>(" << static_cast<double>(copy) << ")";
-					break;
-				default:
-					ss << "<unknown>()";
-					break;
-			}
-
-			return ss.str();
-		}
-	};
-
-	template<>
-	struct StringMaker<ParameterMap>
-	{
-		static std::string convert(const ParameterMap& value)
-		{
-			std::stringstream ss;
-			ss << "{";
-			for(auto& param : value)
-			{
-				ss << "\"" << param.first << "\"=" << StringMaker<XmlRpc::XmlRpcValue>::convert(param.second) << ", ";
-			}
-			ss << "}";
-
-			return ss.str();
-		}
-	};
-}
 
 TEST_CASE("global_param", "[param]")
 {
@@ -80,21 +28,6 @@ TEST_CASE("global_param", "[param]")
 
 	XmlRpc::XmlRpcValue value = it->second;
 	REQUIRE(static_cast<std::string>(value) == "hello_world");
-}
-
-template<class T>
-void checkTypedParam(const ParameterMap& parameters, const std::string& name, XmlRpc::XmlRpcValue::Type expectedType, T expected)
-{
-	CAPTURE(parameters);
-	CAPTURE(name);
-
-	auto it = parameters.find(name);
-	REQUIRE(it != parameters.end());
-
-	XmlRpc::XmlRpcValue value = it->second;
-
-	REQUIRE(value.getType() == expectedType);
-	REQUIRE(static_cast<T>(value) == expected);
 }
 
 TEST_CASE("param_types", "[param]")

--- a/test/xml/test_param.cpp
+++ b/test/xml/test_param.cpp
@@ -1,0 +1,141 @@
+
+#include <catch_ros/catch.hpp>
+
+#include "../../src/launch/launch_config.h"
+
+using namespace rosmon::launch;
+
+typedef std::map<std::string, XmlRpc::XmlRpcValue> ParameterMap;
+
+namespace Catch
+{
+	template<>
+	struct StringMaker<ParameterMap>
+	{
+		static std::string convert(const ParameterMap& value)
+		{
+			std::stringstream ss;
+			ss << "{";
+			for(auto& param : value)
+			{
+				ss << "\"" << param.first << "\"=XmlRpcValue, ";
+			}
+			ss << "}";
+
+			return ss.str();
+		}
+	};
+
+	template<>
+	struct StringMaker<XmlRpc::XmlRpcValue>
+	{
+		static std::string convert(const XmlRpc::XmlRpcValue& value)
+		{
+			// We need a copy, since the cast operators don't work on const
+			// refs *sigh*
+			XmlRpc::XmlRpcValue copy = value;
+
+			std::stringstream ss;
+			ss << "XmlRpc";
+			switch(value.getType())
+			{
+				case XmlRpc::XmlRpcValue::TypeInt:
+					ss << "<int>(" << static_cast<int>(copy) << ")";
+					break;
+				case XmlRpc::XmlRpcValue::TypeBoolean:
+					ss << "<bool>(" << static_cast<bool>(copy) << ")";
+					break;
+				case XmlRpc::XmlRpcValue::TypeString:
+					ss << "<string>(" << static_cast<std::string>(copy) << ")";
+					break;
+				case XmlRpc::XmlRpcValue::TypeDouble:
+					ss << "<double>(" << static_cast<double>(copy) << ")";
+					break;
+				default:
+					ss << "<unknown>()";
+					break;
+			}
+
+			return ss.str();
+		}
+	};
+}
+
+TEST_CASE("global_param", "[param]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<param name="global_param" value="hello_world" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	CAPTURE(config.parameters());
+
+	auto it = config.parameters().find("/global_param");
+
+	REQUIRE(it != config.parameters().end());
+
+	XmlRpc::XmlRpcValue value = it->second;
+	REQUIRE(static_cast<std::string>(value) == "hello_world");
+}
+
+template<class T>
+void checkTypedParam(const ParameterMap& parameters, const std::string& name, XmlRpc::XmlRpcValue::Type expectedType, T expected)
+{
+	CAPTURE(parameters);
+	CAPTURE(name);
+
+	auto it = parameters.find(name);
+	REQUIRE(it != parameters.end());
+
+	XmlRpc::XmlRpcValue value = it->second;
+
+	REQUIRE(value.getType() == expectedType);
+
+	CAPTURE(parameters);
+	CAPTURE(name);
+
+	REQUIRE(static_cast<T>(value) == expected);
+}
+
+TEST_CASE("param_types" "[param]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<param name="int_param_auto" value="0" />
+			<param name="int_param_forced" value="0" type="int" />
+
+			<param name="double_param_auto" value="0.0" />
+			<param name="double_param_forced" value="0" type="double" />
+
+			<param name="str_param_auto" value="hello" />
+			<param name="str_param_forced" value="0" type="str" />
+
+			<param name="bool_param_auto" value="true" />
+			<param name="bool_param_forced" value="true" type="boolean" />
+
+			<param name="yaml_param" type="yaml" value="test_param: true" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto& params = config.parameters();
+	checkTypedParam<int>(params, "/int_param_auto", XmlRpc::XmlRpcValue::TypeInt, 0);
+	checkTypedParam<int>(params, "/int_param_forced", XmlRpc::XmlRpcValue::TypeInt, 0);
+
+	checkTypedParam<double>(params, "/double_param_auto", XmlRpc::XmlRpcValue::TypeDouble, 0.0);
+	checkTypedParam<double>(params, "/double_param_forced", XmlRpc::XmlRpcValue::TypeDouble, 0.0);
+
+	checkTypedParam<std::string>(params, "/str_param_auto", XmlRpc::XmlRpcValue::TypeString, "hello");
+	checkTypedParam<std::string>(params, "/str_param_forced", XmlRpc::XmlRpcValue::TypeString, "0");
+
+	checkTypedParam<bool>(params, "/bool_param_auto", XmlRpc::XmlRpcValue::TypeBoolean, true);
+	checkTypedParam<bool>(params, "/bool_param_forced", XmlRpc::XmlRpcValue::TypeBoolean, true);
+
+	checkTypedParam<bool>(params, "/yaml_param/test_param", XmlRpc::XmlRpcValue::TypeBoolean, true);
+}

--- a/test/xml/test_param.cpp
+++ b/test/xml/test_param.cpp
@@ -78,7 +78,7 @@ TEST_CASE("param command", "[param]")
 		<launch>
 			<param name="test" command="echo -n hello_world" />
 
-			<param name="multiline" command="echo -ne hello\\nworld" />
+			<param name="multiline" command="echo -n hello\\nworld" />
 
 			<param name="yaml_param" type="yaml" command="echo test_param: true" />
 		</launch>

--- a/test/xml/test_param.cpp
+++ b/test/xml/test_param.cpp
@@ -78,7 +78,7 @@ TEST_CASE("param command", "[param]")
 		<launch>
 			<param name="test" command="echo -n hello_world" />
 
-			<param name="multiline" command="echo -n hello\\nworld" />
+			<param name="multiline" command="/bin/echo -ne hello\\nworld" />
 
 			<param name="yaml_param" type="yaml" command="echo test_param: true" />
 		</launch>

--- a/test/xml/test_param.cpp
+++ b/test/xml/test_param.cpp
@@ -202,6 +202,22 @@ TEST_CASE("wrong param types", "[param]")
 	);
 
 	REQUIRE_THROWS_AS(
+		LaunchConfig().parseString(R"EOF(<launch><param name="test" value="invalid: {{ yaml}} here" type="yaml" /></launch>)EOF"),
+		LaunchConfig::ParseException
+	);
+
+	{
+		LaunchConfig config;
+
+		config.parseString(R"EOF(<launch><param name="test" command="echo -ne invalid: {{ yaml}} here" type="yaml" /></launch>)EOF");
+
+		REQUIRE_THROWS_AS(
+			config.evaluateParameters(),
+			LaunchConfig::ParseException
+		);
+	}
+
+	REQUIRE_THROWS_AS(
 		LaunchConfig().parseString(R"EOF(<launch><param name="test" value="0.5" type="unknown_type" /></launch>)EOF"),
 		LaunchConfig::ParseException
 	);

--- a/test/xml/test_param.cpp
+++ b/test/xml/test_param.cpp
@@ -218,4 +218,25 @@ TEST_CASE("invalid param input combinations", "[param]")
 		LaunchConfig().parseString(R"EOF(<launch><param name="test" textfile="$(find rosmon)/test/textfile.txt" command="echo -ne test" /></launch>)EOF"),
 		LaunchConfig::ParseException
 	);
+
+	REQUIRE_THROWS_AS(
+		LaunchConfig().parseString(R"EOF(<launch><param name="test" /></launch>)EOF"),
+		LaunchConfig::ParseException
+	);
 }
+
+TEST_CASE("invalid param names", "[param]")
+{
+	using Catch::Matchers::Contains;
+
+	REQUIRE_THROWS_WITH(
+		LaunchConfig().parseString(R"EOF(<launch><param name="$%*" value="abc" /></launch>)EOF"),
+		Contains("$%*")
+	);
+
+	REQUIRE_THROWS_WITH(
+		LaunchConfig().parseString(R"EOF(<launch><param value="abc" /></launch>)EOF"),
+		Contains("name")
+	);
+}
+

--- a/test/xml/test_rosparam.cpp
+++ b/test/xml/test_rosparam.cpp
@@ -71,6 +71,10 @@ TEST_CASE("rosparam naming", "[rosparam]")
 
 			<arg name="whitelist" default="[3, 2]"/>
 			<rosparam param="whitelist" subst_value="True">$(arg whitelist)</rosparam>
+
+<rosparam ns="namespace">
+a: false
+</rosparam>
 		</launch>
 	)EOF");
 
@@ -101,4 +105,6 @@ TEST_CASE("rosparam naming", "[rosparam]")
 		REQUIRE(value.getType() == XmlRpc::XmlRpcValue::TypeArray);
 		REQUIRE(value.size() == 2);
 	}
+
+	checkTypedParam<bool>(config.parameters(), "/namespace/a", XmlRpc::XmlRpcValue::TypeBoolean, false);
 }

--- a/test/xml/test_rosparam.cpp
+++ b/test/xml/test_rosparam.cpp
@@ -1,0 +1,104 @@
+// Unit tests for rosparam tag
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include <catch_ros/catch.hpp>
+
+#include "../../src/launch/launch_config.h"
+
+#include "param_utils.h"
+
+using namespace rosmon::launch;
+
+TEST_CASE("rosparam basic", "[rosparam]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+<rosparam>
+test_ns:
+  param1: true
+  param2: hello
+  param3: 3
+  param4: 10.0
+</rosparam>
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	CAPTURE(config.parameters());
+
+	auto& params = config.parameters();
+	checkTypedParam<bool>(params, "/test_ns/param1", XmlRpc::XmlRpcValue::TypeBoolean, true);
+	checkTypedParam<std::string>(params, "/test_ns/param2", XmlRpc::XmlRpcValue::TypeString, "hello");
+	checkTypedParam<int>(params, "/test_ns/param3", XmlRpc::XmlRpcValue::TypeInt, 3);
+	checkTypedParam<double>(params, "/test_ns/param4", XmlRpc::XmlRpcValue::TypeDouble, 10.0);
+}
+
+TEST_CASE("rosparam empty", "[rosparam]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+<rosparam>
+</rosparam>
+
+			<rosparam command="load" file="$(find rosmon)/test/empty.yaml" />
+		</launch>
+	)EOF");
+}
+
+TEST_CASE("rosparam invalid YAML", "[rosparam]")
+{
+	REQUIRE_THROWS_AS(
+		LaunchConfig().parseString(R"EOF(
+			<launch>
+<rosparam>
+hello: {{ invalid }} test
+</rosparam>
+			</launch>
+		)EOF"),
+		LaunchConfig::ParseException
+	);
+}
+
+TEST_CASE("rosparam naming", "[rosparam]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<rosparam param="a_list">[1, 2, 3, 4]</rosparam>
+
+			<arg name="whitelist" default="[3, 2]"/>
+			<rosparam param="whitelist" subst_value="True">$(arg whitelist)</rosparam>
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	CAPTURE(config.parameters());
+
+	{
+		INFO("looking for: a_list");
+
+		auto it = config.parameters().find("/a_list");
+		REQUIRE(it != config.parameters().end());
+
+		auto value = it->second;
+
+		REQUIRE(value.getType() == XmlRpc::XmlRpcValue::TypeArray);
+		REQUIRE(value.size() == 4);
+	}
+
+	{
+		INFO("looking for: whitelist");
+
+		auto it = config.parameters().find("/whitelist");
+		REQUIRE(it != config.parameters().end());
+
+		auto value = it->second;
+
+		REQUIRE(value.getType() == XmlRpc::XmlRpcValue::TypeArray);
+		REQUIRE(value.size() == 2);
+	}
+}

--- a/test/xml/test_subst.cpp
+++ b/test/xml/test_subst.cpp
@@ -1,0 +1,171 @@
+// Unit tests for substitution args
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include <boost/filesystem.hpp>
+
+#include <catch_ros/catch.hpp>
+
+#include "../../src/launch/launch_config.h"
+
+#include "param_utils.h"
+
+#include <ros/package.h>
+
+using namespace rosmon::launch;
+
+namespace fs = boost::filesystem;
+
+TEST_CASE("env", "[subst]")
+{
+	SECTION("basic")
+	{
+		LaunchConfig config;
+		config.parseString(R"EOF(
+			<launch>
+				<param name="env_test" value="$(env PATH)" />
+			</launch>
+		)EOF");
+
+		config.evaluateParameters();
+
+		CAPTURE(config.parameters());
+
+		checkTypedParam<std::string>(config.parameters(), "/env_test", XmlRpc::XmlRpcValue::TypeString, getenv("PATH"));
+	}
+
+	SECTION("failure")
+	{
+		REQUIRE_THROWS_AS(
+			LaunchConfig().parseString(R"EOF(
+				<launch>
+					<param name="env_test" value="$(env ROSMON_UNLIKELY_TO_BE_SET)" />
+				</launch>
+			)EOF"),
+			LaunchConfig::ParseException
+		);
+	}
+}
+
+TEST_CASE("optenv", "[subst]")
+{
+	SECTION("present")
+	{
+		LaunchConfig config;
+		config.parseString(R"EOF(
+			<launch>
+				<param name="env_test" value="$(optenv PATH no_such_thing)" />
+			</launch>
+		)EOF");
+
+		config.evaluateParameters();
+
+		CAPTURE(config.parameters());
+
+		checkTypedParam<std::string>(config.parameters(), "/env_test", XmlRpc::XmlRpcValue::TypeString, getenv("PATH"));
+	}
+
+	SECTION("not present")
+	{
+		LaunchConfig config;
+		config.parseString(R"EOF(
+			<launch>
+				<param name="env_test" value="$(optenv ROSMON_UNLIKELY_TO_BE_SET no_such_thing)" />
+			</launch>
+		)EOF");
+
+		config.evaluateParameters();
+
+		CAPTURE(config.parameters());
+
+		checkTypedParam<std::string>(config.parameters(), "/env_test", XmlRpc::XmlRpcValue::TypeString, "no_such_thing");
+	}
+
+	SECTION("not present - long")
+	{
+		LaunchConfig config;
+		config.parseString(R"EOF(
+			<launch>
+				<param name="env_test" value="$(optenv ROSMON_UNLIKELY_TO_BE_SET no such thing)" />
+			</launch>
+		)EOF");
+
+		config.evaluateParameters();
+
+		CAPTURE(config.parameters());
+
+		checkTypedParam<std::string>(config.parameters(), "/env_test", XmlRpc::XmlRpcValue::TypeString, "no such thing");
+	}
+}
+
+TEST_CASE("find", "[subst]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<param name="path_to_rosmon" value="$(find rosmon)" />
+			<param name="path_to_launch_file" value="$(find rosmon)/test/basic.launch" />
+			<param name="path_to_rosmon_executable" value="$(find rosmon)/rosmon" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	CAPTURE(config.parameters());
+
+	checkTypedParam<std::string>(config.parameters(), "/path_to_rosmon", XmlRpc::XmlRpcValue::TypeString, ros::package::getPath("rosmon"));
+	checkTypedParam<std::string>(config.parameters(), "/path_to_launch_file", XmlRpc::XmlRpcValue::TypeString, ros::package::getPath("rosmon") + "/test/basic.launch");
+
+	{
+		INFO("Looking for /path_to_rosmon_executable");
+
+		auto it = config.parameters().find("/path_to_rosmon_executable");
+		REQUIRE(it != config.parameters().end());
+
+		auto value = it->second;
+
+		REQUIRE(value.getType() == XmlRpc::XmlRpcValue::TypeString);
+		auto string = static_cast<std::string>(value);
+
+		CHECK((fs::status(string).permissions() & fs::owner_exe));
+	}
+}
+
+TEST_CASE("anon", "[subst]")
+{
+	SECTION("regular use")
+	{
+		LaunchConfig config;
+		config.parseString(R"EOF(
+			<launch>
+				<param name="test_1" value="$(anon rviz-1)" />
+				<param name="test_2" value="$(anon rviz-1)" />
+				<param name="test_3" value="$(anon rviz-2)" />
+			</launch>
+		)EOF");
+
+		config.evaluateParameters();
+
+		CAPTURE(config.parameters());
+
+		auto test1 = getTypedParam<std::string>(config.parameters(), "/test_1");
+		auto test2 = getTypedParam<std::string>(config.parameters(), "/test_2");
+		auto test3 = getTypedParam<std::string>(config.parameters(), "/test_3");
+
+		CHECK(test1 == test2);
+		CHECK(test1 != test3);
+	}
+
+	SECTION("clash example")
+	{
+		// from http://wiki.ros.org/roslaunch/XML
+		REQUIRE_THROWS_AS(
+			LaunchConfig().parseString(R"EOF(
+				<launch>
+					<node name="$(anon foo)" pkg="rospy_tutorials" type="talker.py" />
+					<node name="$(anon foo)" pkg="rospy_tutorials" type="talker.py" />
+				</launch>
+			)EOF"),
+			LaunchConfig::ParseException
+		);
+	}
+}


### PR DESCRIPTION
So far, we only have an integration-level test launch file in `test/`. This PR adds unit tests on the XML parsing level (`launch` namespace in rosmon). The tests were written following the [roslaunch/XML][1] wiki page and should cover all tags/attributes mentioned there.

This introduces a test dependency on [catch_ros][2].

Also fixes a number of minor problems uncovered by the unit tests:

 * handle `<param type="yaml">`
 * report `<param command="...">` failures properly
 * accept `True` and `False` as booleans (not mentioned in spec, but roslaunch does it)
 * report python exceptions correctly
 * add support for `<node cwd="...">`
 * add support for `<node clear_params="...">`
 * fix int type deduction for `$(eval ...)`
 * add error on dangerous `<include clear_params="true">`

[1]: https://wiki.ros.org/roslaunch/XML
[2]: https://github.com/AIS-Bonn/catch_ros.git