### PR TITLE
Port all string formatting to fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ if(BUILD_FOR_COVERAGE)
 	endif()
 endif()
 
+add_subdirectory(contrib/fmt)
+
 add_library(rosmon_launch_config
 	src/launch/node.cpp
 	src/launch/launch_config.cpp
@@ -78,6 +80,7 @@ target_link_libraries(rosmon_launch_config
 	${catkin_LIBRARIES}
 	${TinyXML_LIBRARIES}
 	${Boost_LIBRARIES}
+	rosmon_fmt
 	yaml-cpp
 )
 

--- a/README.md
+++ b/README.md
@@ -5,36 +5,9 @@
 `rosmon` is a drop-in replacement for the standard `roslaunch` tool. Rather
 unlike `roslaunch`, `rosmon` is focused on (remote) process monitoring.
 
-## Quick & effective development
-
- * Modern console UI with colored indicators for each node. With one glance
-   you can see that everything is still running as it should.
- * Debugger integration:
-   * Automatic coredump collection for dying processes
-   * Launch `gdb` against your running process or post-mortem against the
-     collected coredump
- * `rosmon` intercepts all `stdout/stderr` from your nodes and tags it with
-   a timestamp and the node name. No more wondering which of your nodes the
-   mysterious warning came from.
-
-## Interaction
-
-`rosmon` includes a simple keyboard user interface: Each node has an assigned
-key. If you press that key, you get a menu in the status line which allows you
-to start, stop, or debug a coredump of that very node.
-
-## Remote control
-
-`rosmon` offers a simple but effective ROS interface to start, stop or restart
-nodes and monitor node states. Restarting a single stuck node out of the launch
-file is no longer a problem. An `rqt` plugin for controlling `rosmon` is
-included.
-
-## Security
-
-`rosmon` disables the "Yama" `ptrace()` protection from its child processes, so
-that the user can attach with `gdb` without needing root privileges.
-This may be seen as a security risk.
+Please see the [ROS wiki page](https://wiki.ros.org/rosmon) for further
+information, the rest of this README contains information for `rosmon`
+developers.
 
 ## Building
 
@@ -42,31 +15,12 @@ Simple include this repository in your catkin workspace. After a build
 (tested with `catkin_tools`) and re-sourcing of the `devel/setup.bash` you will
 have the `mon` command in your environment.
 
-`mon` supports the same argument style as `roslaunch` (either
-`mon launch path/to/file.launch` or `mon launch package file.launch`).
-
-## Robust core dump collection
-
-rosmon will try to collect coredumps automatically on node crashes. However,
-the default setting for `/proc/sys/kernel/core_pattern` is `core`, which means
-that the coredump will be created in the working directory of the process.
-rosmon therefore creates separate temporary working directories for the nodes.
-
-If this is problematic (e.g. your nodes expect a certain working directory
-or change working directory at runtime), you can setup a fixed `core_pattern`
-on your system.
-Add the following lines to `/etc/rc.local`:
-
-    mkdir /tmp/cores
-    chmod a+rw /tmp/cores
-    echo "/tmp/cores/core.%e.%p.%t" > /proc/sys/kernel/core_pattern
-
-and reboot (or execute `/etc/rc.local` once).
-
 ## License
 
-`rosmon` is licensed under BSD-3.
+`rosmon` is licensed under BSD-3. The `rosmon` repository includes the
+[fmt](http://fmtlib.net/latest/index.html) library, which is also licensed
+under BSD-2.
 
 ## Author
 
-Max Schwarz <max.schwarz@uni-bonn.de>
+Max Schwarz <max.schwarz@ais.uni-bonn.de>

--- a/contrib/fmt/CMakeLists.txt
+++ b/contrib/fmt/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+add_library(rosmon_fmt
+	src/format.cc
+	src/posix.cc
+)
+
+target_include_directories(rosmon_fmt PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}/include
+)

--- a/contrib/fmt/CMakeLists.txt
+++ b/contrib/fmt/CMakeLists.txt
@@ -7,3 +7,8 @@ add_library(rosmon_fmt
 target_include_directories(rosmon_fmt PUBLIC
 	${CMAKE_CURRENT_SOURCE_DIR}/include
 )
+
+install(TARGETS rosmon_fmt
+	LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+	RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/contrib/fmt/LICENSE.rst
+++ b/contrib/fmt/LICENSE.rst
@@ -1,0 +1,23 @@
+Copyright (c) 2012 - 2016, Victor Zverovich
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/contrib/fmt/README.md
+++ b/contrib/fmt/README.md
@@ -1,0 +1,2 @@
+
+see https://github.com/fmtlib/fmt/.

--- a/contrib/fmt/include/fmt/core.h
+++ b/contrib/fmt/include/fmt/core.h
@@ -52,8 +52,8 @@
 // GCC doesn't allow throw in constexpr until version 6 (bug 67371).
 #ifndef FMT_USE_CONSTEXPR
 # define FMT_USE_CONSTEXPR \
-  (FMT_HAS_FEATURE(cxx_relaxed_constexpr) || FMT_GCC_VERSION >= 600 || \
-   FMT_MSC_VER >= 1910)
+  (FMT_HAS_FEATURE(cxx_relaxed_constexpr) || FMT_MSC_VER >= 1910 || \
+   (FMT_GCC_VERSION >= 600 && __cplusplus >= 201402L))
 #endif
 #if FMT_USE_CONSTEXPR
 # define FMT_CONSTEXPR constexpr

--- a/contrib/fmt/include/fmt/core.h
+++ b/contrib/fmt/include/fmt/core.h
@@ -1,0 +1,1293 @@
+// Formatting library for C++ - the core API
+//
+// Copyright (c) 2012 - present, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_CORE_H_
+#define FMT_CORE_H_
+
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <iterator>
+#include <string>
+#include <type_traits>
+
+// The fmt library version in the form major * 10000 + minor * 100 + patch.
+#define FMT_VERSION 50000
+
+#ifdef __has_feature
+# define FMT_HAS_FEATURE(x) __has_feature(x)
+#else
+# define FMT_HAS_FEATURE(x) 0
+#endif
+
+#ifdef __has_include
+# define FMT_HAS_INCLUDE(x) __has_include(x)
+#else
+# define FMT_HAS_INCLUDE(x) 0
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+# define FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+#else
+# define FMT_GCC_VERSION 0
+#endif
+
+#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+# define FMT_HAS_GXX_CXX11 FMT_GCC_VERSION
+#else
+# define FMT_HAS_GXX_CXX11 0
+#endif
+
+#ifdef _MSC_VER
+# define FMT_MSC_VER _MSC_VER
+#else
+# define FMT_MSC_VER 0
+#endif
+
+// Check if relaxed c++14 constexpr is supported.
+// GCC doesn't allow throw in constexpr until version 6 (bug 67371).
+#ifndef FMT_USE_CONSTEXPR
+# define FMT_USE_CONSTEXPR \
+  (FMT_HAS_FEATURE(cxx_relaxed_constexpr) || FMT_GCC_VERSION >= 600 || \
+   FMT_MSC_VER >= 1910)
+#endif
+#if FMT_USE_CONSTEXPR
+# define FMT_CONSTEXPR constexpr
+# define FMT_CONSTEXPR_DECL constexpr
+#else
+# define FMT_CONSTEXPR inline
+# define FMT_CONSTEXPR_DECL
+#endif
+
+#ifndef FMT_OVERRIDE
+# if FMT_HAS_FEATURE(cxx_override) || \
+     (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || \
+     FMT_MSC_VER >= 1900
+#  define FMT_OVERRIDE override
+# else
+#  define FMT_OVERRIDE
+# endif
+#endif
+
+#if FMT_HAS_FEATURE(cxx_explicit_conversions)
+# define FMT_EXPLICIT explicit
+#else
+# define FMT_EXPLICIT
+#endif
+
+#ifndef FMT_NULL
+# if FMT_HAS_FEATURE(cxx_nullptr) || \
+   (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || \
+   FMT_MSC_VER >= 1600
+#  define FMT_NULL nullptr
+#  define FMT_USE_NULLPTR 1
+# else
+#  define FMT_NULL NULL
+# endif
+#endif
+
+#ifndef FMT_USE_NULLPTR
+# define FMT_USE_NULLPTR 0
+#endif
+
+// Check if exceptions are disabled.
+#if defined(__GNUC__) && !defined(__EXCEPTIONS)
+# define FMT_EXCEPTIONS 0
+#elif FMT_MSC_VER && !_HAS_EXCEPTIONS
+# define FMT_EXCEPTIONS 0
+#endif
+#ifndef FMT_EXCEPTIONS
+# define FMT_EXCEPTIONS 1
+#endif
+
+// Define FMT_USE_NOEXCEPT to make fmt use noexcept (C++11 feature).
+#ifndef FMT_USE_NOEXCEPT
+# define FMT_USE_NOEXCEPT 0
+#endif
+
+#if FMT_USE_NOEXCEPT || FMT_HAS_FEATURE(cxx_noexcept) || \
+    (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || \
+    FMT_MSC_VER >= 1900
+# define FMT_DETECTED_NOEXCEPT noexcept
+#else
+# define FMT_DETECTED_NOEXCEPT throw()
+#endif
+
+#ifndef FMT_NOEXCEPT
+# if FMT_EXCEPTIONS
+#  define FMT_NOEXCEPT FMT_DETECTED_NOEXCEPT
+# else
+#  define FMT_NOEXCEPT
+# endif
+#endif
+
+// This is needed because GCC still uses throw() in its headers when exceptions
+// are disabled.
+#if FMT_GCC_VERSION
+# define FMT_DTOR_NOEXCEPT FMT_DETECTED_NOEXCEPT
+#else
+# define FMT_DTOR_NOEXCEPT FMT_NOEXCEPT
+#endif
+
+#if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
+# ifdef FMT_EXPORT
+#  define FMT_API __declspec(dllexport)
+# elif defined(FMT_SHARED)
+#  define FMT_API __declspec(dllimport)
+# endif
+#endif
+#ifndef FMT_API
+# define FMT_API
+#endif
+
+#ifndef FMT_ASSERT
+# define FMT_ASSERT(condition, message) assert((condition) && message)
+#endif
+
+#define FMT_DELETED = delete
+
+// A macro to disallow the copy construction and assignment.
+#define FMT_DISALLOW_COPY_AND_ASSIGN(Type) \
+    Type(const Type &) FMT_DELETED; \
+    void operator=(const Type &) FMT_DELETED
+
+// libc++ supports string_view in pre-c++17.
+#if (FMT_HAS_INCLUDE(<string_view>) && \
+      (__cplusplus > 201402L || defined(_LIBCPP_VERSION))) || \
+    (defined(_MSVC_LANG) && _MSVC_LANG > 201402L && _MSC_VER >= 1910)
+# include <string_view>
+# define FMT_USE_STD_STRING_VIEW
+#elif (FMT_HAS_INCLUDE(<experimental/string_view>) && \
+       __cplusplus >= 201402L)
+# include <experimental/string_view>
+# define FMT_USE_EXPERIMENTAL_STRING_VIEW
+#endif
+
+// std::result_of is defined in <functional> in gcc 4.4.
+#if FMT_GCC_VERSION && FMT_GCC_VERSION <= 404
+# include <functional>
+#endif
+
+namespace fmt {
+
+// An implementation of declval for pre-C++11 compilers such as gcc 4.
+namespace internal {
+template <typename T>
+typename std::add_rvalue_reference<T>::type declval() FMT_NOEXCEPT;
+}
+
+/**
+  \rst
+  An implementation of ``std::basic_string_view`` for pre-C++17. It provides a
+  subset of the API. ``fmt::basic_string_view`` is used for format strings even
+  if ``std::string_view`` is available to prevent issues when a library is
+  compiled with a different ``-std`` option than the client code (which is not
+  recommended).
+  \endrst
+ */
+template <typename Char>
+class basic_string_view {
+ private:
+  const Char *data_;
+  size_t size_;
+
+ public:
+  typedef Char char_type;
+  typedef const Char *iterator;
+
+  // Standard basic_string_view type.
+#if defined(FMT_USE_STD_STRING_VIEW)
+  typedef std::basic_string_view<Char> type;
+#elif defined(FMT_USE_EXPERIMENTAL_STRING_VIEW)
+  typedef std::experimental::basic_string_view<Char> type;
+#else
+  struct type {
+    const char *data() const { return FMT_NULL; }
+    size_t size() const { return 0; };
+  };
+#endif
+
+  FMT_CONSTEXPR basic_string_view() FMT_NOEXCEPT : data_(FMT_NULL), size_(0) {}
+
+  /** Constructs a string reference object from a C string and a size. */
+  FMT_CONSTEXPR basic_string_view(const Char *s, size_t size) FMT_NOEXCEPT
+    : data_(s), size_(size) {}
+
+  /**
+    \rst
+    Constructs a string reference object from a C string computing
+    the size with ``std::char_traits<Char>::length``.
+    \endrst
+   */
+  basic_string_view(const Char *s)
+    : data_(s), size_(std::char_traits<Char>::length(s)) {}
+
+  /**
+    \rst
+    Constructs a string reference from a ``std::basic_string`` object.
+    \endrst
+   */
+  template <typename Alloc>
+  FMT_CONSTEXPR basic_string_view(
+      const std::basic_string<Char, Alloc> &s) FMT_NOEXCEPT
+  : data_(s.c_str()), size_(s.size()) {}
+
+  FMT_CONSTEXPR basic_string_view(type s) FMT_NOEXCEPT
+  : data_(s.data()), size_(s.size()) {}
+
+  /** Returns a pointer to the string data. */
+  const Char *data() const { return data_; }
+
+  /** Returns the string size. */
+  FMT_CONSTEXPR size_t size() const { return size_; }
+
+  FMT_CONSTEXPR iterator begin() const { return data_; }
+  FMT_CONSTEXPR iterator end() const { return data_ + size_; }
+
+  FMT_CONSTEXPR void remove_prefix(size_t n) {
+    data_ += n;
+    size_ -= n;
+  }
+
+  // Lexicographically compare this string reference to other.
+  int compare(basic_string_view other) const {
+    size_t size = size_ < other.size_ ? size_ : other.size_;
+    int result = std::char_traits<Char>::compare(data_, other.data_, size);
+    if (result == 0)
+      result = size_ == other.size_ ? 0 : (size_ < other.size_ ? -1 : 1);
+    return result;
+  }
+
+  friend bool operator==(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) == 0;
+  }
+  friend bool operator!=(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) != 0;
+  }
+  friend bool operator<(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) < 0;
+  }
+  friend bool operator<=(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) <= 0;
+  }
+  friend bool operator>(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) > 0;
+  }
+  friend bool operator>=(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) >= 0;
+  }
+};
+
+typedef basic_string_view<char> string_view;
+typedef basic_string_view<wchar_t> wstring_view;
+
+template <typename Context>
+class basic_format_arg;
+
+template <typename Context>
+class basic_format_args;
+
+// A formatter for objects of type T.
+template <typename T, typename Char = char, typename Enable = void>
+struct formatter;
+
+namespace internal {
+
+/** A contiguous memory buffer with an optional growing ability. */
+template <typename T>
+class basic_buffer {
+ private:
+  FMT_DISALLOW_COPY_AND_ASSIGN(basic_buffer);
+
+  T *ptr_;
+  std::size_t size_;
+  std::size_t capacity_;
+
+ protected:
+  basic_buffer(T *p = FMT_NULL, std::size_t size = 0, std::size_t capacity = 0)
+    FMT_NOEXCEPT: ptr_(p), size_(size), capacity_(capacity) {}
+
+  /** Sets the buffer data and capacity. */
+  void set(T *data, std::size_t capacity) FMT_NOEXCEPT {
+    ptr_ = data;
+    capacity_ = capacity;
+  }
+
+  /**
+    \rst
+    Increases the buffer capacity to hold at least *capacity* elements.
+    \endrst
+   */
+  virtual void grow(std::size_t capacity) = 0;
+
+ public:
+  typedef T value_type;
+  typedef const T &const_reference;
+
+  virtual ~basic_buffer() {}
+
+  T *begin() FMT_NOEXCEPT { return ptr_; }
+  T *end() FMT_NOEXCEPT { return ptr_ + size_; }
+
+  /** Returns the size of this buffer. */
+  std::size_t size() const FMT_NOEXCEPT { return size_; }
+
+  /** Returns the capacity of this buffer. */
+  std::size_t capacity() const FMT_NOEXCEPT { return capacity_; }
+
+  /** Returns a pointer to the buffer data. */
+  T *data() FMT_NOEXCEPT { return ptr_; }
+
+  /** Returns a pointer to the buffer data. */
+  const T *data() const FMT_NOEXCEPT { return ptr_; }
+
+  /**
+    Resizes the buffer. If T is a POD type new elements may not be initialized.
+   */
+  void resize(std::size_t new_size) {
+    reserve(new_size);
+    size_ = new_size;
+  }
+
+  /**
+    \rst
+    Reserves space to store at least *capacity* elements.
+    \endrst
+   */
+  void reserve(std::size_t capacity) {
+    if (capacity > capacity_)
+      grow(capacity);
+  }
+
+  void push_back(const T &value) {
+    reserve(size_ + 1);
+    ptr_[size_++] = value;
+  }
+
+  /** Appends data to the end of the buffer. */
+  template <typename U>
+  void append(const U *begin, const U *end);
+
+  T &operator[](std::size_t index) { return ptr_[index]; }
+  const T &operator[](std::size_t index) const { return ptr_[index]; }
+};
+
+typedef basic_buffer<char> buffer;
+typedef basic_buffer<wchar_t> wbuffer;
+
+// A container-backed buffer.
+template <typename Container>
+class container_buffer : public basic_buffer<typename Container::value_type> {
+ private:
+  Container &container_;
+
+ protected:
+  void grow(std::size_t capacity) FMT_OVERRIDE {
+    container_.resize(capacity);
+    this->set(&container_[0], capacity);
+  }
+
+ public:
+  explicit container_buffer(Container &c)
+    : basic_buffer<typename Container::value_type>(&c[0], c.size(), c.size()),
+      container_(c) {}
+};
+
+struct error_handler {
+  FMT_CONSTEXPR error_handler() {}
+  FMT_CONSTEXPR error_handler(const error_handler &) {}
+
+  // This function is intentionally not constexpr to give a compile-time error.
+  FMT_API void on_error(const char *message);
+};
+
+// Formatting of wide characters and strings into a narrow output is disallowed:
+//   fmt::format("{}", L"test"); // error
+// To fix this, use a wide format string:
+//   fmt::format(L"{}", L"test");
+template <typename Char>
+inline void require_wchar() {
+  static_assert(
+      std::is_same<wchar_t, Char>::value,
+      "formatting of wide characters into a narrow output is disallowed");
+}
+
+template <typename Char>
+struct named_arg_base;
+
+template <typename T, typename Char>
+struct named_arg;
+
+template <typename T>
+struct is_named_arg : std::false_type {};
+
+template <typename T, typename Char>
+struct is_named_arg<named_arg<T, Char>> : std::true_type {};
+
+enum type {
+  none_type, name_arg_type,
+  // Integer types should go first,
+  int_type, uint_type, long_long_type, ulong_long_type, bool_type, char_type,
+  last_integer_type = char_type,
+  // followed by floating-point types.
+  double_type, long_double_type, last_numeric_type = long_double_type,
+  cstring_type, string_type, pointer_type, custom_type
+};
+
+FMT_CONSTEXPR bool is_integral(type t) {
+  FMT_ASSERT(t != internal::name_arg_type, "invalid argument type");
+  return t > internal::none_type && t <= internal::last_integer_type;
+}
+
+FMT_CONSTEXPR bool is_arithmetic(type t) {
+  FMT_ASSERT(t != internal::name_arg_type, "invalid argument type");
+  return t > internal::none_type && t <= internal::last_numeric_type;
+}
+
+template <typename T, typename Char, bool ENABLE = true>
+struct convert_to_int {
+  enum {
+    value = !std::is_arithmetic<T>::value && std::is_convertible<T, int>::value
+  };
+};
+
+template <typename Char>
+struct string_value {
+  const Char *value;
+  std::size_t size;
+};
+
+template <typename Context>
+struct custom_value {
+  const void *value;
+  void (*format)(const void *arg, Context &ctx);
+};
+
+// A formatting argument value.
+template <typename Context>
+class value {
+ public:
+  typedef typename Context::char_type char_type;
+
+  union {
+    int int_value;
+    unsigned uint_value;
+    long long long_long_value;
+    unsigned long long ulong_long_value;
+    double double_value;
+    long double long_double_value;
+    const void *pointer;
+    string_value<char_type> string;
+    string_value<signed char> sstring;
+    string_value<unsigned char> ustring;
+    custom_value<Context> custom;
+  };
+
+  FMT_CONSTEXPR value(int val = 0) : int_value(val) {}
+  value(unsigned val) { uint_value = val; }
+  value(long long val) { long_long_value = val; }
+  value(unsigned long long val) { ulong_long_value = val; }
+  value(double val) { double_value = val; }
+  value(long double val) { long_double_value = val; }
+  value(const char_type *val) { string.value = val; }
+  value(const signed char *val) {
+    static_assert(std::is_same<char, char_type>::value,
+                  "incompatible string types");
+    sstring.value = val;
+  }
+  value(const unsigned char *val) {
+    static_assert(std::is_same<char, char_type>::value,
+                  "incompatible string types");
+    ustring.value = val;
+  }
+  value(basic_string_view<char_type> val) {
+    string.value = val.data();
+    string.size = val.size();
+  }
+  value(const void *val) { pointer = val; }
+
+  template <typename T>
+  explicit value(const T &val) {
+    custom.value = &val;
+    custom.format = &format_custom_arg<T>;
+  }
+
+  const named_arg_base<char_type> &as_named_arg() {
+    return *static_cast<const named_arg_base<char_type>*>(pointer);
+  }
+
+ private:
+  // Formats an argument of a custom type, such as a user-defined class.
+  template <typename T>
+  static void format_custom_arg(const void *arg, Context &ctx) {
+    // Get the formatter type through the context to allow different contexts
+    // have different extension points, e.g. `formatter<T>` for `format` and
+    // `printf_formatter<T>` for `printf`.
+    typename Context::template formatter_type<T>::type f;
+    auto &&parse_ctx = ctx.parse_context();
+    parse_ctx.advance_to(f.parse(parse_ctx));
+    ctx.advance_to(f.format(*static_cast<const T*>(arg), ctx));
+  }
+};
+
+template <typename Context, type TYPE>
+struct typed_value : value<Context> {
+  static const type type_tag = TYPE;
+
+  template <typename T>
+  FMT_CONSTEXPR typed_value(const T &val) : value<Context>(val) {}
+};
+
+template <typename Context, typename T>
+FMT_CONSTEXPR basic_format_arg<Context> make_arg(const T &value);
+
+#define FMT_MAKE_VALUE(TAG, ArgType, ValueType) \
+  template <typename C> \
+  FMT_CONSTEXPR typed_value<C, TAG> make_value(ArgType val) { \
+    return static_cast<ValueType>(val); \
+  }
+
+FMT_MAKE_VALUE(bool_type, bool, int)
+FMT_MAKE_VALUE(int_type, short, int)
+FMT_MAKE_VALUE(uint_type, unsigned short, unsigned)
+FMT_MAKE_VALUE(int_type, int, int)
+FMT_MAKE_VALUE(uint_type, unsigned, unsigned)
+
+// To minimize the number of types we need to deal with, long is translated
+// either to int or to long long depending on its size.
+typedef std::conditional<sizeof(long) == sizeof(int), int, long long>::type
+        long_type;
+FMT_MAKE_VALUE(
+    (sizeof(long) == sizeof(int) ? int_type : long_long_type), long, long_type)
+typedef std::conditional<sizeof(unsigned long) == sizeof(unsigned),
+                         unsigned, unsigned long long>::type ulong_type;
+FMT_MAKE_VALUE(
+    (sizeof(unsigned long) == sizeof(unsigned) ? uint_type : ulong_long_type),
+    unsigned long, ulong_type)
+
+FMT_MAKE_VALUE(long_long_type, long long, long long)
+FMT_MAKE_VALUE(ulong_long_type, unsigned long long, unsigned long long)
+FMT_MAKE_VALUE(int_type, signed char, int)
+FMT_MAKE_VALUE(uint_type, unsigned char, unsigned)
+FMT_MAKE_VALUE(char_type, char, int)
+
+#if !defined(_MSC_VER) || defined(_NATIVE_WCHAR_T_DEFINED)
+template <typename C>
+inline typed_value<C, char_type> make_value(wchar_t val) {
+  require_wchar<typename C::char_type>();
+  return static_cast<int>(val);
+}
+#endif
+
+FMT_MAKE_VALUE(double_type, float, double)
+FMT_MAKE_VALUE(double_type, double, double)
+FMT_MAKE_VALUE(long_double_type, long double, long double)
+
+// Formatting of wide strings into a narrow buffer and multibyte strings
+// into a wide buffer is disallowed (https://github.com/fmtlib/fmt/pull/606).
+FMT_MAKE_VALUE(cstring_type, typename C::char_type*,
+               const typename C::char_type*)
+FMT_MAKE_VALUE(cstring_type, const typename C::char_type*,
+               const typename C::char_type*)
+
+FMT_MAKE_VALUE(cstring_type, signed char*, const signed char*)
+FMT_MAKE_VALUE(cstring_type, const signed char*, const signed char*)
+FMT_MAKE_VALUE(cstring_type, unsigned char*, const unsigned char*)
+FMT_MAKE_VALUE(cstring_type, const unsigned char*, const unsigned char*)
+FMT_MAKE_VALUE(string_type, basic_string_view<typename C::char_type>,
+               basic_string_view<typename C::char_type>)
+FMT_MAKE_VALUE(string_type,
+               typename basic_string_view<typename C::char_type>::type,
+               basic_string_view<typename C::char_type>)
+FMT_MAKE_VALUE(string_type, const std::basic_string<typename C::char_type>&,
+               basic_string_view<typename C::char_type>)
+FMT_MAKE_VALUE(pointer_type, void*, const void*)
+FMT_MAKE_VALUE(pointer_type, const void*, const void*)
+
+#if FMT_USE_NULLPTR
+FMT_MAKE_VALUE(pointer_type, std::nullptr_t, const void*)
+#endif
+
+// Formatting of arbitrary pointers is disallowed. If you want to output a
+// pointer cast it to "void *" or "const void *". In particular, this forbids
+// formatting of "[const] volatile char *" which is printed as bool by
+// iostreams.
+template <typename C, typename T>
+typed_value<C, pointer_type> make_value(const T *) {
+  static_assert(!sizeof(T), "formatting of non-void pointers is disallowed");
+}
+
+template <typename C, typename T>
+inline typename std::enable_if<
+    std::is_enum<T>::value && convert_to_int<T, typename C::char_type>::value,
+    typed_value<C, int_type>>::type
+  make_value(const T &val) { return static_cast<int>(val); }
+
+template <typename C, typename T, typename Char = typename C::char_type>
+inline typename std::enable_if<
+    !convert_to_int<T, Char>::value &&
+    !std::is_convertible<T, basic_string_view<Char>>::value &&
+    !std::is_convertible<T, std::basic_string<Char>>::value,
+    typed_value<C, custom_type>>::type
+  make_value(const T &val) { return val; }
+
+template <typename C, typename T>
+typed_value<C, name_arg_type>
+    make_value(const named_arg<T, typename C::char_type> &val) {
+  basic_format_arg<C> arg = make_arg<C>(val.value);
+  std::memcpy(val.data, &arg, sizeof(arg));
+  return static_cast<const void*>(&val);
+}
+
+// Maximum number of arguments with packed types.
+enum { max_packed_args = 15 };
+
+template <typename Context>
+class arg_map;
+
+template <typename>
+struct result_of;
+
+template <typename F, typename... Args>
+struct result_of<F(Args...)> {
+  // A workaround for gcc 4.4 that doesn't allow F to be a reference.
+  typedef typename std::result_of<
+    typename std::remove_reference<F>::type(Args...)>::type type;
+};
+}
+
+// A formatting argument. It is a trivially copyable/constructible type to
+// allow storage in basic_memory_buffer.
+template <typename Context>
+class basic_format_arg {
+ private:
+  internal::value<Context> value_;
+  internal::type type_;
+
+  template <typename ContextType, typename T>
+  friend FMT_CONSTEXPR basic_format_arg<ContextType>
+    internal::make_arg(const T &value);
+
+  template <typename Visitor, typename Ctx>
+  friend FMT_CONSTEXPR typename internal::result_of<Visitor(int)>::type
+    visit(Visitor &&vis, basic_format_arg<Ctx> arg);
+
+  friend class basic_format_args<Context>;
+  friend class internal::arg_map<Context>;
+
+  typedef typename Context::char_type char_type;
+
+ public:
+  class handle {
+   public:
+    explicit handle(internal::custom_value<Context> custom): custom_(custom) {}
+
+    void format(Context &ctx) const { custom_.format(custom_.value, ctx); }
+
+   private:
+    internal::custom_value<Context> custom_;
+  };
+
+  FMT_CONSTEXPR basic_format_arg() : type_(internal::none_type) {}
+
+  FMT_EXPLICIT operator bool() const FMT_NOEXCEPT {
+    return type_ != internal::none_type;
+  }
+
+  internal::type type() const { return type_; }
+
+  bool is_integral() const { return internal::is_integral(type_); }
+  bool is_arithmetic() const { return internal::is_arithmetic(type_); }
+};
+
+// Parsing context consisting of a format string range being parsed and an
+// argument counter for automatic indexing.
+template <typename Char, typename ErrorHandler = internal::error_handler>
+class basic_parse_context : private ErrorHandler {
+ private:
+  basic_string_view<Char> format_str_;
+  int next_arg_id_;
+
+ public:
+  typedef Char char_type;
+  typedef typename basic_string_view<Char>::iterator iterator;
+
+  explicit FMT_CONSTEXPR basic_parse_context(
+      basic_string_view<Char> format_str, ErrorHandler eh = ErrorHandler())
+    : ErrorHandler(eh), format_str_(format_str), next_arg_id_(0) {}
+
+  // Returns an iterator to the beginning of the format string range being
+  // parsed.
+  FMT_CONSTEXPR iterator begin() const FMT_NOEXCEPT {
+    return format_str_.begin();
+  }
+
+  // Returns an iterator past the end of the format string range being parsed.
+  FMT_CONSTEXPR iterator end() const FMT_NOEXCEPT { return format_str_.end(); }
+
+  // Advances the begin iterator to ``it``.
+  FMT_CONSTEXPR void advance_to(iterator it) {
+    format_str_.remove_prefix(it - begin());
+  }
+
+  // Returns the next argument index.
+  FMT_CONSTEXPR unsigned next_arg_id();
+
+  FMT_CONSTEXPR bool check_arg_id(unsigned) {
+    if (next_arg_id_ > 0) {
+      on_error("cannot switch from automatic to manual argument indexing");
+      return false;
+    }
+    next_arg_id_ = -1;
+    return true;
+  }
+  void check_arg_id(basic_string_view<Char>) {}
+
+  FMT_CONSTEXPR void on_error(const char *message) {
+    ErrorHandler::on_error(message);
+  }
+
+  FMT_CONSTEXPR ErrorHandler error_handler() const { return *this; }
+};
+
+typedef basic_parse_context<char> parse_context;
+typedef basic_parse_context<wchar_t> wparse_context;
+
+namespace internal {
+// A map from argument names to their values for named arguments.
+template <typename Context>
+class arg_map {
+ private:
+  FMT_DISALLOW_COPY_AND_ASSIGN(arg_map);
+
+  typedef typename Context::char_type char_type;
+
+  struct entry {
+    basic_string_view<char_type> name;
+    basic_format_arg<Context> arg;
+  };
+
+  entry *map_;
+  unsigned size_;
+
+  void push_back(value<Context> val) {
+    const internal::named_arg_base<char_type> &named = val.as_named_arg();
+    map_[size_] = entry{named.name, named.template deserialize<Context>()};
+    ++size_;
+  }
+
+ public:
+  arg_map() : map_(FMT_NULL), size_(0) {}
+  void init(const basic_format_args<Context> &args);
+  ~arg_map() { delete [] map_; }
+
+  basic_format_arg<Context> find(basic_string_view<char_type> name) const {
+    // The list is unsorted, so just return the first matching name.
+    for (auto it = map_, end = map_ + size_; it != end; ++it) {
+      if (it->name == name)
+        return it->arg;
+    }
+    return basic_format_arg<Context>();
+  }
+};
+
+template <typename OutputIt, typename Context, typename Char>
+class context_base {
+ public:
+  typedef OutputIt iterator;
+
+ private:
+  basic_parse_context<Char> parse_context_;
+  iterator out_;
+  basic_format_args<Context> args_;
+
+ protected:
+  typedef Char char_type;
+  typedef basic_format_arg<Context> format_arg;
+
+  context_base(OutputIt out, basic_string_view<char_type> format_str,
+               basic_format_args<Context> args)
+  : parse_context_(format_str), out_(out), args_(args) {}
+
+  // Returns the argument with specified index.
+  format_arg do_get_arg(unsigned arg_id) {
+    format_arg arg = args_.get(arg_id);
+    if (!arg)
+      parse_context_.on_error("argument index out of range");
+    return arg;
+  }
+
+  // Checks if manual indexing is used and returns the argument with
+  // specified index.
+  format_arg get_arg(unsigned arg_id) {
+    return this->parse_context().check_arg_id(arg_id) ?
+      this->do_get_arg(arg_id) : format_arg();
+  }
+
+ public:
+  basic_parse_context<char_type> &parse_context() {
+    return parse_context_;
+  }
+
+  internal::error_handler error_handler() {
+    return parse_context_.error_handler();
+  }
+
+  void on_error(const char *message) { parse_context_.on_error(message); }
+
+  // Returns an iterator to the beginning of the output range.
+  iterator out() { return out_; }
+  iterator begin() { return out_; }  // deprecated
+
+  // Advances the begin iterator to ``it``.
+  void advance_to(iterator it) { out_ = it; }
+
+  basic_format_args<Context> args() const { return args_; }
+};
+
+// Extracts a reference to the container from back_insert_iterator.
+template <typename Container>
+inline Container &get_container(std::back_insert_iterator<Container> it) {
+  typedef std::back_insert_iterator<Container> bi_iterator;
+  struct accessor: bi_iterator {
+    accessor(bi_iterator iter) : bi_iterator(iter) {}
+    using bi_iterator::container;
+  };
+  return *accessor(it).container;
+}
+}  // namespace internal
+
+// Formatting context.
+template <typename OutputIt, typename Char>
+class basic_format_context :
+  public internal::context_base<
+    OutputIt, basic_format_context<OutputIt, Char>, Char> {
+ public:
+  /** The character type for the output. */
+  typedef Char char_type;
+
+  // using formatter_type = formatter<T, char_type>;
+  template <typename T>
+  struct formatter_type { typedef formatter<T, char_type> type; };
+
+ private:
+  internal::arg_map<basic_format_context> map_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(basic_format_context);
+
+  typedef internal::context_base<OutputIt, basic_format_context, Char> base;
+  typedef typename base::format_arg format_arg;
+  using base::get_arg;
+
+ public:
+  using typename base::iterator;
+
+  /**
+   \rst
+   Constructs a ``basic_format_context`` object. References to the arguments are
+   stored in the object so make sure they have appropriate lifetimes.
+   \endrst
+   */
+  basic_format_context(OutputIt out, basic_string_view<char_type> format_str,
+                basic_format_args<basic_format_context> args)
+    : base(out, format_str, args) {}
+
+  format_arg next_arg() {
+    return this->do_get_arg(this->parse_context().next_arg_id());
+  }
+  format_arg get_arg(unsigned arg_id) { return this->do_get_arg(arg_id); }
+
+  // Checks if manual indexing is used and returns the argument with the
+  // specified name.
+  format_arg get_arg(basic_string_view<char_type> name);
+};
+
+template <typename Char>
+struct buffer_context {
+  typedef basic_format_context<
+    std::back_insert_iterator<internal::basic_buffer<Char>>, Char> type;
+};
+typedef buffer_context<char>::type format_context;
+typedef buffer_context<wchar_t>::type wformat_context;
+
+namespace internal {
+template <typename Context, typename T>
+struct get_type {
+  typedef decltype(make_value<Context>(
+        declval<typename std::decay<T>::type&>())) value_type;
+  static const type value = value_type::type_tag;
+};
+
+template <typename Context>
+FMT_CONSTEXPR uint64_t get_types() { return 0; }
+
+template <typename Context, typename Arg, typename... Args>
+FMT_CONSTEXPR uint64_t get_types() {
+  return get_type<Context, Arg>::value | (get_types<Context, Args...>() << 4);
+}
+
+template <typename Context, typename T>
+FMT_CONSTEXPR basic_format_arg<Context> make_arg(const T &value) {
+  basic_format_arg<Context> arg;
+  arg.type_ = get_type<Context, T>::value;
+  arg.value_ = make_value<Context>(value);
+  return arg;
+}
+
+template <bool IS_PACKED, typename Context, typename T>
+inline typename std::enable_if<IS_PACKED, value<Context>>::type
+    make_arg(const T &value) {
+  return make_value<Context>(value);
+}
+
+template <bool IS_PACKED, typename Context, typename T>
+inline typename std::enable_if<!IS_PACKED, basic_format_arg<Context>>::type
+    make_arg(const T &value) {
+  return make_arg<Context>(value);
+}
+}
+
+/**
+  \rst
+  An array of references to arguments. It can be implicitly converted into
+  `~fmt::basic_format_args` for passing into type-erased formatting functions
+  such as `~fmt::vformat`.
+  \endrst
+ */
+template <typename Context, typename ...Args>
+class format_arg_store {
+ private:
+  static const size_t NUM_ARGS = sizeof...(Args);
+
+  // Packed is a macro on MinGW so use IS_PACKED instead.
+  static const bool IS_PACKED = NUM_ARGS < internal::max_packed_args;
+
+  typedef typename std::conditional<IS_PACKED,
+    internal::value<Context>, basic_format_arg<Context>>::type value_type;
+
+  // If the arguments are not packed, add one more element to mark the end.
+  value_type data_[NUM_ARGS + (IS_PACKED && NUM_ARGS != 0 ? 0 : 1)];
+
+  friend class basic_format_args<Context>;
+
+ public:
+  static const uint64_t TYPES;
+
+#if FMT_GCC_VERSION && FMT_GCC_VERSION <= 405
+  // Workaround an array initialization bug in gcc 4.5 and earlier.
+  format_arg_store(const Args &... args) {
+    data_ = {internal::make_arg<IS_PACKED, Context>(args)...};
+  }
+#else
+  format_arg_store(const Args &... args)
+    : data_{internal::make_arg<IS_PACKED, Context>(args)...} {}
+#endif
+};
+
+template <typename Context, typename ...Args>
+const uint64_t format_arg_store<Context, Args...>::TYPES = IS_PACKED ?
+    internal::get_types<Context, Args...>() :
+    -static_cast<int64_t>(NUM_ARGS);
+
+/**
+  \rst
+  Constructs an `~fmt::format_arg_store` object that contains references to
+  arguments and can be implicitly converted to `~fmt::format_args`. `Context` can
+  be omitted in which case it defaults to `~fmt::context`.
+  \endrst
+ */
+template <typename Context, typename ...Args>
+inline format_arg_store<Context, Args...>
+    make_format_args(const Args & ... args) {
+  return format_arg_store<Context, Args...>(args...);
+}
+
+template <typename ...Args>
+inline format_arg_store<format_context, Args...>
+    make_format_args(const Args & ... args) {
+  return format_arg_store<format_context, Args...>(args...);
+}
+
+/** Formatting arguments. */
+template <typename Context>
+class basic_format_args {
+ public:
+  typedef unsigned size_type;
+  typedef basic_format_arg<Context>  format_arg;
+
+ private:
+  // To reduce compiled code size per formatting function call, types of first
+  // max_packed_args arguments are passed in the types_ field.
+  uint64_t types_;
+  union {
+    // If the number of arguments is less than max_packed_args, the argument
+    // values are stored in values_, otherwise they are stored in args_.
+    // This is done to reduce compiled code size as storing larger objects
+    // may require more code (at least on x86-64) even if the same amount of
+    // data is actually copied to stack. It saves ~10% on the bloat test.
+    const internal::value<Context> *values_;
+    const format_arg *args_;
+  };
+
+  typename internal::type type(unsigned index) const {
+    unsigned shift = index * 4;
+    uint64_t mask = 0xf;
+    return static_cast<typename internal::type>(
+      (types_ & (mask << shift)) >> shift);
+  }
+
+  friend class internal::arg_map<Context>;
+
+  void set_data(const internal::value<Context> *values) { values_ = values; }
+  void set_data(const format_arg *args) { args_ = args; }
+
+  format_arg do_get(size_type index) const {
+    int64_t signed_types = static_cast<int64_t>(types_);
+    if (signed_types < 0) {
+      uint64_t num_args = -signed_types;
+      return index < num_args ? args_[index] : format_arg();
+    }
+    format_arg arg;
+    if (index > internal::max_packed_args)
+      return arg;
+    arg.type_ = type(index);
+    if (arg.type_ == internal::none_type)
+      return arg;
+    internal::value<Context> &val = arg.value_;
+    val = values_[index];
+    return arg;
+  }
+
+ public:
+  basic_format_args() : types_(0) {}
+
+  /**
+   \rst
+   Constructs a `basic_format_args` object from `~fmt::format_arg_store`.
+   \endrst
+   */
+  template <typename... Args>
+  basic_format_args(const format_arg_store<Context, Args...> &store)
+  : types_(store.TYPES) {
+    set_data(store.data_);
+  }
+
+  /** Returns the argument at specified index. */
+  format_arg get(size_type index) const {
+    format_arg arg = do_get(index);
+    return arg.type_ == internal::name_arg_type ?
+          arg.value_.as_named_arg().template deserialize<Context>() : arg;
+  }
+
+  unsigned max_size() const {
+    int64_t signed_types = static_cast<int64_t>(types_);
+    return static_cast<unsigned>(
+        signed_types < 0 ?
+        -signed_types : static_cast<int64_t>(internal::max_packed_args));
+  }
+};
+
+/** An alias to ``basic_format_args<context>``. */
+// It is a separate type rather than a typedef to make symbols readable.
+struct format_args: basic_format_args<format_context> {
+  template <typename ...Args>
+  format_args(Args && ... arg)
+  : basic_format_args<format_context>(std::forward<Args>(arg)...) {}
+};
+struct wformat_args : basic_format_args<wformat_context> {
+  template <typename ...Args>
+  wformat_args(Args && ... arg)
+  : basic_format_args<wformat_context>(std::forward<Args>(arg)...) {}
+};
+
+namespace internal {
+template <typename Char>
+struct named_arg_base {
+  basic_string_view<Char> name;
+
+  // Serialized value<context>.
+  mutable char data[sizeof(basic_format_arg<format_context>)];
+
+  named_arg_base(basic_string_view<Char> nm) : name(nm) {}
+
+  template <typename Context>
+  basic_format_arg<Context> deserialize() const {
+    basic_format_arg<Context> arg;
+    std::memcpy(&arg, data, sizeof(basic_format_arg<Context>));
+    return arg;
+  }
+};
+
+template <typename T, typename Char>
+struct named_arg : named_arg_base<Char> {
+  const T &value;
+
+  named_arg(basic_string_view<Char> name, const T &val)
+    : named_arg_base<Char>(name), value(val) {}
+};
+}
+
+/**
+  \rst
+  Returns a named argument to be used in a formatting function.
+
+  **Example**::
+
+    fmt::print("Elapsed time: {s:.2f} seconds", fmt::arg("s", 1.23));
+  \endrst
+ */
+template <typename T>
+inline internal::named_arg<T, char> arg(string_view name, const T &arg) {
+  return internal::named_arg<T, char>(name, arg);
+}
+
+template <typename T>
+inline internal::named_arg<T, wchar_t> arg(wstring_view name, const T &arg) {
+  return internal::named_arg<T, wchar_t>(name, arg);
+}
+
+// This function template is deleted intentionally to disable nested named
+// arguments as in ``format("{}", arg("a", arg("b", 42)))``.
+template <typename S, typename T, typename Char>
+void arg(S, internal::named_arg<T, Char>) FMT_DELETED;
+
+enum color { black, red, green, yellow, blue, magenta, cyan, white };
+
+FMT_API void vprint_colored(color c, string_view format, format_args args);
+FMT_API void vprint_colored(color c, wstring_view format, wformat_args args);
+
+/**
+  Formats a string and prints it to stdout using ANSI escape sequences to
+  specify color (experimental).
+  Example:
+    fmt::print_colored(fmt::RED, "Elapsed time: {0:.2f} seconds", 1.23);
+ */
+template <typename... Args>
+inline void print_colored(color c, string_view format_str,
+                          const Args & ... args) {
+  vprint_colored(c, format_str, make_format_args(args...));
+}
+
+template <typename... Args>
+inline void print_colored(color c, wstring_view format_str,
+                          const Args & ... args) {
+  vprint_colored(c, format_str, make_format_args<wformat_context>(args...));
+}
+
+format_context::iterator vformat_to(
+    internal::buffer &buf, string_view format_str, format_args args);
+wformat_context::iterator vformat_to(
+    internal::wbuffer &buf, wstring_view format_str, wformat_args args);
+
+template <typename Container>
+struct is_contiguous : std::false_type {};
+
+template <typename Char>
+struct is_contiguous<std::basic_string<Char>> : std::true_type {};
+
+template <typename Char>
+struct is_contiguous<fmt::internal::basic_buffer<Char>> : std::true_type {};
+
+/** Formats a string and writes the output to ``out``. */
+template <typename Container>
+typename std::enable_if<
+  is_contiguous<Container>::value, std::back_insert_iterator<Container>>::type
+    vformat_to(std::back_insert_iterator<Container> out,
+               string_view format_str, format_args args) {
+  auto& container = internal::get_container(out);
+  internal::container_buffer<Container> buf(container);
+  vformat_to(buf, format_str, args);
+  return std::back_inserter(container);
+}
+
+template <typename Container>
+typename std::enable_if<
+  is_contiguous<Container>::value, std::back_insert_iterator<Container>>::type
+  vformat_to(std::back_insert_iterator<Container> out,
+             wstring_view format_str, wformat_args args) {
+  auto& container = internal::get_container(out);
+  internal::container_buffer<Container> buf(container);
+  vformat_to(buf, format_str, args);
+  return std::back_inserter(container);
+}
+
+std::string vformat(string_view format_str, format_args args);
+std::wstring vformat(wstring_view format_str, wformat_args args);
+
+/**
+  \rst
+  Formats arguments and returns the result as a string.
+
+  **Example**::
+
+    #include <fmt/core.h>
+    std::string message = fmt::format("The answer is {}", 42);
+  \endrst
+*/
+template <typename... Args>
+inline std::string format(string_view format_str, const Args & ... args) {
+  // This should be just
+  // return vformat(format_str, make_format_args(args...));
+  // but gcc has trouble optimizing the latter, so break it down.
+  format_arg_store<format_context, Args...> as(args...);
+  return vformat(format_str, as);
+}
+template <typename... Args>
+inline std::wstring format(wstring_view format_str, const Args & ... args) {
+  format_arg_store<wformat_context, Args...> as(args...);
+  return vformat(format_str, as);
+}
+
+FMT_API void vprint(std::FILE *f, string_view format_str, format_args args);
+FMT_API void vprint(std::FILE *f, wstring_view format_str, wformat_args args);
+
+/**
+  \rst
+  Prints formatted data to the file *f*.
+
+  **Example**::
+
+    fmt::print(stderr, "Don't {}!", "panic");
+  \endrst
+ */
+template <typename... Args>
+inline void print(std::FILE *f, string_view format_str, const Args & ... args) {
+  format_arg_store<format_context, Args...> as(args...);
+  vprint(f, format_str, as);
+}
+template <typename... Args>
+inline void print(std::FILE *f, wstring_view format_str, const Args & ... args) {
+  format_arg_store<wformat_context, Args...> as(args...);
+  vprint(f, format_str, as);
+}
+
+FMT_API void vprint(string_view format_str, format_args args);
+FMT_API void vprint(wstring_view format_str, wformat_args args);
+
+/**
+  \rst
+  Prints formatted data to ``stdout``.
+
+  **Example**::
+
+    fmt::print("Elapsed time: {0:.2f} seconds", 1.23);
+  \endrst
+ */
+template <typename... Args>
+inline void print(string_view format_str, const Args & ... args) {
+  format_arg_store<format_context, Args...> as(args...);
+  vprint(format_str, as);
+}
+
+template <typename... Args>
+inline void print(wstring_view format_str, const Args & ... args) {
+  format_arg_store<wformat_context, Args...> as(args...);
+  vprint(format_str, as);
+}
+}  // namespace fmt
+
+#endif  // FMT_CORE_H_

--- a/contrib/fmt/include/fmt/format-inl.h
+++ b/contrib/fmt/include/fmt/format-inl.h
@@ -1,0 +1,531 @@
+// Formatting library for C++
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_FORMAT_INL_H_
+#define FMT_FORMAT_INL_H_
+
+#include "format.h"
+#include "locale.h"
+
+#include <string.h>
+
+#include <cctype>
+#include <cerrno>
+#include <climits>
+#include <cmath>
+#include <cstdarg>
+#include <cstddef>  // for std::ptrdiff_t
+
+#if defined(_WIN32) && defined(__MINGW32__)
+# include <cstring>
+#endif
+
+#if FMT_USE_WINDOWS_H
+# if !defined(FMT_HEADER_ONLY) && !defined(WIN32_LEAN_AND_MEAN)
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# if defined(NOMINMAX) || defined(FMT_WIN_MINMAX)
+#  include <windows.h>
+# else
+#  define NOMINMAX
+#  include <windows.h>
+#  undef NOMINMAX
+# endif
+#endif
+
+#if FMT_EXCEPTIONS
+# define FMT_TRY try
+# define FMT_CATCH(x) catch (x)
+#else
+# define FMT_TRY if (true)
+# define FMT_CATCH(x) if (false)
+#endif
+
+#ifdef __GNUC__
+// Disable the warning about declaration shadowing because it affects too
+// many valid cases.
+# pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable: 4127)  // conditional expression is constant
+# pragma warning(disable: 4702)  // unreachable code
+// Disable deprecation warning for strerror. The latter is not called but
+// MSVC fails to detect it.
+# pragma warning(disable: 4996)
+#endif
+
+// Dummy implementations of strerror_r and strerror_s called if corresponding
+// system functions are not available.
+inline fmt::internal::null<> strerror_r(int, char *, ...) {
+  return fmt::internal::null<>();
+}
+inline fmt::internal::null<> strerror_s(char *, std::size_t, ...) {
+  return fmt::internal::null<>();
+}
+
+namespace fmt {
+
+FMT_FUNC format_error::~format_error() throw() {}
+FMT_FUNC system_error::~system_error() FMT_DTOR_NOEXCEPT {}
+
+namespace {
+
+#ifndef _MSC_VER
+# define FMT_SNPRINTF snprintf
+#else  // _MSC_VER
+inline int fmt_snprintf(char *buffer, size_t size, const char *format, ...) {
+  va_list args;
+  va_start(args, format);
+  int result = vsnprintf_s(buffer, size, _TRUNCATE, format, args);
+  va_end(args);
+  return result;
+}
+# define FMT_SNPRINTF fmt_snprintf
+#endif  // _MSC_VER
+
+#if defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
+# define FMT_SWPRINTF snwprintf
+#else
+# define FMT_SWPRINTF swprintf
+#endif // defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
+
+const char RESET_COLOR[] = "\x1b[0m";
+const wchar_t WRESET_COLOR[] = L"\x1b[0m"; 
+
+typedef void (*FormatFunc)(internal::buffer &, int, string_view);
+
+// Portable thread-safe version of strerror.
+// Sets buffer to point to a string describing the error code.
+// This can be either a pointer to a string stored in buffer,
+// or a pointer to some static immutable string.
+// Returns one of the following values:
+//   0      - success
+//   ERANGE - buffer is not large enough to store the error message
+//   other  - failure
+// Buffer should be at least of size 1.
+int safe_strerror(
+    int error_code, char *&buffer, std::size_t buffer_size) FMT_NOEXCEPT {
+  FMT_ASSERT(buffer != FMT_NULL && buffer_size != 0, "invalid buffer");
+
+  class StrError {
+   private:
+    int error_code_;
+    char *&buffer_;
+    std::size_t buffer_size_;
+
+    // A noop assignment operator to avoid bogus warnings.
+    void operator=(const StrError &) {}
+
+    // Handle the result of XSI-compliant version of strerror_r.
+    int handle(int result) {
+      // glibc versions before 2.13 return result in errno.
+      return result == -1 ? errno : result;
+    }
+
+    // Handle the result of GNU-specific version of strerror_r.
+    int handle(char *message) {
+      // If the buffer is full then the message is probably truncated.
+      if (message == buffer_ && strlen(buffer_) == buffer_size_ - 1)
+        return ERANGE;
+      buffer_ = message;
+      return 0;
+    }
+
+    // Handle the case when strerror_r is not available.
+    int handle(internal::null<>) {
+      return fallback(strerror_s(buffer_, buffer_size_, error_code_));
+    }
+
+    // Fallback to strerror_s when strerror_r is not available.
+    int fallback(int result) {
+      // If the buffer is full then the message is probably truncated.
+      return result == 0 && strlen(buffer_) == buffer_size_ - 1 ?
+            ERANGE : result;
+    }
+
+    // Fallback to strerror if strerror_r and strerror_s are not available.
+    int fallback(internal::null<>) {
+      errno = 0;
+      buffer_ = strerror(error_code_);
+      return errno;
+    }
+
+   public:
+    StrError(int err_code, char *&buf, std::size_t buf_size)
+      : error_code_(err_code), buffer_(buf), buffer_size_(buf_size) {}
+
+    int run() {
+      return handle(strerror_r(error_code_, buffer_, buffer_size_));
+    }
+  };
+  return StrError(error_code, buffer, buffer_size).run();
+}
+
+void format_error_code(internal::buffer &out, int error_code,
+                       string_view message) FMT_NOEXCEPT {
+  // Report error code making sure that the output fits into
+  // inline_buffer_size to avoid dynamic memory allocation and potential
+  // bad_alloc.
+  out.resize(0);
+  static const char SEP[] = ": ";
+  static const char ERROR_STR[] = "error ";
+  // Subtract 2 to account for terminating null characters in SEP and ERROR_STR.
+  std::size_t error_code_size = sizeof(SEP) + sizeof(ERROR_STR) - 2;
+  typedef internal::int_traits<int>::main_type main_type;
+  main_type abs_value = static_cast<main_type>(error_code);
+  if (internal::is_negative(error_code)) {
+    abs_value = 0 - abs_value;
+    ++error_code_size;
+  }
+  error_code_size += internal::count_digits(abs_value);
+  writer w(out);
+  if (message.size() <= inline_buffer_size - error_code_size) {
+    w.write(message);
+    w.write(SEP);
+  }
+  w.write(ERROR_STR);
+  w.write(error_code);
+  assert(out.size() <= inline_buffer_size);
+}
+
+void report_error(FormatFunc func, int error_code,
+                  string_view message) FMT_NOEXCEPT {
+  memory_buffer full_message;
+  func(full_message, error_code, message);
+  // Use Writer::data instead of Writer::c_str to avoid potential memory
+  // allocation.
+  std::fwrite(full_message.data(), full_message.size(), 1, stderr);
+  std::fputc('\n', stderr);
+}
+}  // namespace
+
+template <typename Char>
+FMT_FUNC Char internal::thousands_sep(locale_provider *lp) {
+  std::locale loc = lp ? lp->locale().get() : std::locale();
+  return std::use_facet<std::numpunct<Char>>(loc).thousands_sep();
+}
+
+FMT_FUNC void system_error::init(
+    int err_code, string_view format_str, format_args args) {
+  error_code_ = err_code;
+  memory_buffer buffer;
+  format_system_error(buffer, err_code, vformat(format_str, args));
+  std::runtime_error &base = *this;
+  base = std::runtime_error(to_string(buffer));
+}
+
+namespace internal {
+template <typename T>
+int char_traits<char>::format_float(
+    char *buffer, std::size_t size, const char *format,
+    unsigned width, int precision, T value) {
+  if (width == 0) {
+    return precision < 0 ?
+        FMT_SNPRINTF(buffer, size, format, value) :
+        FMT_SNPRINTF(buffer, size, format, precision, value);
+  }
+  return precision < 0 ?
+      FMT_SNPRINTF(buffer, size, format, width, value) :
+      FMT_SNPRINTF(buffer, size, format, width, precision, value);
+}
+
+template <typename T>
+int char_traits<wchar_t>::format_float(
+    wchar_t *buffer, std::size_t size, const wchar_t *format,
+    unsigned width, int precision, T value) {
+  if (width == 0) {
+    return precision < 0 ?
+        FMT_SWPRINTF(buffer, size, format, value) :
+        FMT_SWPRINTF(buffer, size, format, precision, value);
+  }
+  return precision < 0 ?
+      FMT_SWPRINTF(buffer, size, format, width, value) :
+      FMT_SWPRINTF(buffer, size, format, width, precision, value);
+}
+
+template <typename T>
+const char basic_data<T>::DIGITS[] =
+    "0001020304050607080910111213141516171819"
+    "2021222324252627282930313233343536373839"
+    "4041424344454647484950515253545556575859"
+    "6061626364656667686970717273747576777879"
+    "8081828384858687888990919293949596979899";
+
+#define FMT_POWERS_OF_10(factor) \
+  factor * 10, \
+  factor * 100, \
+  factor * 1000, \
+  factor * 10000, \
+  factor * 100000, \
+  factor * 1000000, \
+  factor * 10000000, \
+  factor * 100000000, \
+  factor * 1000000000
+
+template <typename T>
+const uint32_t basic_data<T>::POWERS_OF_10_32[] = {
+  0, FMT_POWERS_OF_10(1)
+};
+
+template <typename T>
+const uint64_t basic_data<T>::POWERS_OF_10_64[] = {
+  0,
+  FMT_POWERS_OF_10(1),
+  FMT_POWERS_OF_10(1000000000ull),
+  10000000000000000000ull
+};
+
+// Normalized 64-bit significands of pow(10, k), for k = -348, -340, ..., 340.
+// These are generated by support/compute-powers.py.
+template <typename T>
+const uint64_t basic_data<T>::POW10_SIGNIFICANDS[] = {
+  0xfa8fd5a0081c0288ull, 0xbaaee17fa23ebf76ull, 0x8b16fb203055ac76ull,
+  0xcf42894a5dce35eaull, 0x9a6bb0aa55653b2dull, 0xe61acf033d1a45dfull,
+  0xab70fe17c79ac6caull, 0xff77b1fcbebcdc4full, 0xbe5691ef416bd60cull,
+  0x8dd01fad907ffc3cull, 0xd3515c2831559a83ull, 0x9d71ac8fada6c9b5ull,
+  0xea9c227723ee8bcbull, 0xaecc49914078536dull, 0x823c12795db6ce57ull,
+  0xc21094364dfb5637ull, 0x9096ea6f3848984full, 0xd77485cb25823ac7ull,
+  0xa086cfcd97bf97f4ull, 0xef340a98172aace5ull, 0xb23867fb2a35b28eull,
+  0x84c8d4dfd2c63f3bull, 0xc5dd44271ad3cdbaull, 0x936b9fcebb25c996ull,
+  0xdbac6c247d62a584ull, 0xa3ab66580d5fdaf6ull, 0xf3e2f893dec3f126ull,
+  0xb5b5ada8aaff80b8ull, 0x87625f056c7c4a8bull, 0xc9bcff6034c13053ull,
+  0x964e858c91ba2655ull, 0xdff9772470297ebdull, 0xa6dfbd9fb8e5b88full,
+  0xf8a95fcf88747d94ull, 0xb94470938fa89bcfull, 0x8a08f0f8bf0f156bull,
+  0xcdb02555653131b6ull, 0x993fe2c6d07b7facull, 0xe45c10c42a2b3b06ull,
+  0xaa242499697392d3ull, 0xfd87b5f28300ca0eull, 0xbce5086492111aebull,
+  0x8cbccc096f5088ccull, 0xd1b71758e219652cull, 0x9c40000000000000ull,
+  0xe8d4a51000000000ull, 0xad78ebc5ac620000ull, 0x813f3978f8940984ull,
+  0xc097ce7bc90715b3ull, 0x8f7e32ce7bea5c70ull, 0xd5d238a4abe98068ull,
+  0x9f4f2726179a2245ull, 0xed63a231d4c4fb27ull, 0xb0de65388cc8ada8ull,
+  0x83c7088e1aab65dbull, 0xc45d1df942711d9aull, 0x924d692ca61be758ull,
+  0xda01ee641a708deaull, 0xa26da3999aef774aull, 0xf209787bb47d6b85ull,
+  0xb454e4a179dd1877ull, 0x865b86925b9bc5c2ull, 0xc83553c5c8965d3dull,
+  0x952ab45cfa97a0b3ull, 0xde469fbd99a05fe3ull, 0xa59bc234db398c25ull,
+  0xf6c69a72a3989f5cull, 0xb7dcbf5354e9beceull, 0x88fcf317f22241e2ull,
+  0xcc20ce9bd35c78a5ull, 0x98165af37b2153dfull, 0xe2a0b5dc971f303aull,
+  0xa8d9d1535ce3b396ull, 0xfb9b7cd9a4a7443cull, 0xbb764c4ca7a44410ull,
+  0x8bab8eefb6409c1aull, 0xd01fef10a657842cull, 0x9b10a4e5e9913129ull,
+  0xe7109bfba19c0c9dull, 0xac2820d9623bf429ull, 0x80444b5e7aa7cf85ull,
+  0xbf21e44003acdd2dull, 0x8e679c2f5e44ff8full, 0xd433179d9c8cb841ull,
+  0x9e19db92b4e31ba9ull, 0xeb96bf6ebadf77d9ull, 0xaf87023b9bf0ee6bull
+};
+
+// Binary exponents of pow(10, k), for k = -348, -340, ..., 340, corresponding
+// to significands above.
+template <typename T>
+const int16_t basic_data<T>::POW10_EXPONENTS[] = {
+  -1220, -1193, -1166, -1140, -1113, -1087, -1060, -1034, -1007,  -980,  -954,
+   -927,  -901,  -874,  -847,  -821,  -794,  -768,  -741,  -715,  -688,  -661,
+   -635,  -608,  -582,  -555,  -529,  -502,  -475,  -449,  -422,  -396,  -369,
+   -343,  -316,  -289,  -263,  -236,  -210,  -183,  -157,  -130,  -103,   -77,
+    -50,   -24,     3,    30,    56,    83,   109,   136,   162,   189,   216,
+    242,   269,   295,   322,   348,   375,   402,   428,   455,   481,   508,
+    534,   561,   588,   614,   641,   667,   694,   720,   747,   774,   800,
+    827,   853,   880,   907,   933,   960,   986,  1013,  1039,  1066
+};
+
+FMT_FUNC fp operator*(fp x, fp y) {
+  // Multiply 32-bit parts of significands.
+  uint64_t mask = (1ULL << 32) - 1;
+  uint64_t a = x.f >> 32, b = x.f & mask;
+  uint64_t c = y.f >> 32, d = y.f & mask;
+  uint64_t ac = a * c, bc = b * c, ad = a * d, bd = b * d;
+  // Compute mid 64-bit of result and round.
+  uint64_t mid = (bd >> 32) + (ad & mask) + (bc & mask) + (1U << 31);
+  return fp(ac + (ad >> 32) + (bc >> 32) + (mid >> 32), x.e + y.e + 64);
+}
+}  // namespace internal
+
+#if FMT_USE_WINDOWS_H
+
+FMT_FUNC internal::utf8_to_utf16::utf8_to_utf16(string_view s) {
+  static const char ERROR_MSG[] = "cannot convert string from UTF-8 to UTF-16";
+  if (s.size() > INT_MAX)
+    FMT_THROW(windows_error(ERROR_INVALID_PARAMETER, ERROR_MSG));
+  int s_size = static_cast<int>(s.size());
+  if (s_size == 0) {
+    // MultiByteToWideChar does not support zero length, handle separately.
+    buffer_.resize(1);
+    buffer_[0] = 0;
+    return;
+  }
+
+  int length = MultiByteToWideChar(
+      CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size, FMT_NULL, 0);
+  if (length == 0)
+    FMT_THROW(windows_error(GetLastError(), ERROR_MSG));
+  buffer_.resize(length + 1);
+  length = MultiByteToWideChar(
+    CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size, &buffer_[0], length);
+  if (length == 0)
+    FMT_THROW(windows_error(GetLastError(), ERROR_MSG));
+  buffer_[length] = 0;
+}
+
+FMT_FUNC internal::utf16_to_utf8::utf16_to_utf8(wstring_view s) {
+  if (int error_code = convert(s)) {
+    FMT_THROW(windows_error(error_code,
+        "cannot convert string from UTF-16 to UTF-8"));
+  }
+}
+
+FMT_FUNC int internal::utf16_to_utf8::convert(wstring_view s) {
+  if (s.size() > INT_MAX)
+    return ERROR_INVALID_PARAMETER;
+  int s_size = static_cast<int>(s.size());
+  if (s_size == 0) {
+    // WideCharToMultiByte does not support zero length, handle separately.
+    buffer_.resize(1);
+    buffer_[0] = 0;
+    return 0;
+  }
+
+  int length = WideCharToMultiByte(
+        CP_UTF8, 0, s.data(), s_size, FMT_NULL, 0, FMT_NULL, FMT_NULL);
+  if (length == 0)
+    return GetLastError();
+  buffer_.resize(length + 1);
+  length = WideCharToMultiByte(
+    CP_UTF8, 0, s.data(), s_size, &buffer_[0], length, FMT_NULL, FMT_NULL);
+  if (length == 0)
+    return GetLastError();
+  buffer_[length] = 0;
+  return 0;
+}
+
+FMT_FUNC void windows_error::init(
+    int err_code, string_view format_str, format_args args) {
+  error_code_ = err_code;
+  memory_buffer buffer;
+  internal::format_windows_error(buffer, err_code, vformat(format_str, args));
+  std::runtime_error &base = *this;
+  base = std::runtime_error(to_string(buffer));
+}
+
+FMT_FUNC void internal::format_windows_error(
+    internal::buffer &out, int error_code, string_view message) FMT_NOEXCEPT {
+  FMT_TRY {
+    wmemory_buffer buf;
+    buf.resize(inline_buffer_size);
+    for (;;) {
+      wchar_t *system_message = &buf[0];
+      int result = FormatMessageW(
+          FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+          FMT_NULL, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+          system_message, static_cast<uint32_t>(buf.size()), FMT_NULL);
+      if (result != 0) {
+        utf16_to_utf8 utf8_message;
+        if (utf8_message.convert(system_message) == ERROR_SUCCESS) {
+          writer w(out);
+          w.write(message);
+          w.write(": ");
+          w.write(utf8_message);
+          return;
+        }
+        break;
+      }
+      if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+        break;  // Can't get error message, report error code instead.
+      buf.resize(buf.size() * 2);
+    }
+  } FMT_CATCH(...) {}
+  format_error_code(out, error_code, message);
+}
+
+#endif  // FMT_USE_WINDOWS_H
+
+FMT_FUNC void format_system_error(
+    internal::buffer &out, int error_code, string_view message) FMT_NOEXCEPT {
+  FMT_TRY {
+    memory_buffer buf;
+    buf.resize(inline_buffer_size);
+    for (;;) {
+      char *system_message = &buf[0];
+      int result = safe_strerror(error_code, system_message, buf.size());
+      if (result == 0) {
+        writer w(out);
+        w.write(message);
+        w.write(": ");
+        w.write(system_message);
+        return;
+      }
+      if (result != ERANGE)
+        break;  // Can't get error message, report error code instead.
+      buf.resize(buf.size() * 2);
+    }
+  } FMT_CATCH(...) {}
+  format_error_code(out, error_code, message);
+}
+
+template <typename Char>
+void basic_fixed_buffer<Char>::grow(std::size_t) {
+  FMT_THROW(std::runtime_error("buffer overflow"));
+}
+
+FMT_FUNC void internal::error_handler::on_error(const char *message) {
+  FMT_THROW(format_error(message));
+}
+
+FMT_FUNC void report_system_error(
+    int error_code, fmt::string_view message) FMT_NOEXCEPT {
+  report_error(format_system_error, error_code, message);
+}
+
+#if FMT_USE_WINDOWS_H
+FMT_FUNC void report_windows_error(
+    int error_code, fmt::string_view message) FMT_NOEXCEPT {
+  report_error(internal::format_windows_error, error_code, message);
+}
+#endif
+
+FMT_FUNC void vprint(std::FILE *f, string_view format_str, format_args args) {
+  memory_buffer buffer;
+  vformat_to(buffer, format_str, args);
+  std::fwrite(buffer.data(), 1, buffer.size(), f);
+}
+
+FMT_FUNC void vprint(std::FILE *f, wstring_view format_str, wformat_args args) {
+  wmemory_buffer buffer;
+  vformat_to(buffer, format_str, args);
+  std::fwrite(buffer.data(), sizeof(wchar_t), buffer.size(), f);
+}
+
+FMT_FUNC void vprint(string_view format_str, format_args args) {
+  vprint(stdout, format_str, args);
+}
+
+FMT_FUNC void vprint(wstring_view format_str, wformat_args args) {
+  vprint(stdout, format_str, args);
+}
+
+FMT_FUNC void vprint_colored(color c, string_view format, format_args args) {
+  char escape[] = "\x1b[30m";
+  escape[3] = static_cast<char>('0' + c);
+  std::fputs(escape, stdout);
+  vprint(format, args);
+  std::fputs(RESET_COLOR, stdout);
+}
+
+FMT_FUNC void vprint_colored(color c, wstring_view format, wformat_args args) {
+  wchar_t escape[] = L"\x1b[30m";
+  escape[3] = static_cast<wchar_t>('0' + c);
+  std::fputws(escape, stdout);
+  vprint(format, args);
+  std::fputws(WRESET_COLOR, stdout);
+}
+
+FMT_FUNC locale locale_provider::locale() { return fmt::locale(); }
+
+}  // namespace fmt
+
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif
+
+#endif  // FMT_FORMAT_INL_H_

--- a/contrib/fmt/include/fmt/format.h
+++ b/contrib/fmt/include/fmt/format.h
@@ -116,7 +116,7 @@
 #endif
 
 #if FMT_USE_USER_DEFINED_LITERALS && \
-    (FMT_GCC_VERSION >= 600 || \
+    ((FMT_GCC_VERSION >= 600 && __cplusplus >= 201402L) || \
     (defined(FMT_CLANG_VERSION) && FMT_CLANG_VERSION >= 304))
 # define FMT_UDL_TEMPLATE 1
 #else

--- a/contrib/fmt/include/fmt/format.h
+++ b/contrib/fmt/include/fmt/format.h
@@ -1,0 +1,3656 @@
+/*
+ Formatting library for C++
+
+ Copyright (c) 2012 - present, Victor Zverovich
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FMT_FORMAT_H_
+#define FMT_FORMAT_H_
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <stdint.h>
+
+#include "core.h"
+
+#ifdef _SECURE_SCL
+# define FMT_SECURE_SCL _SECURE_SCL
+#else
+# define FMT_SECURE_SCL 0
+#endif
+
+#if FMT_SECURE_SCL
+# include <iterator>
+#endif
+
+#ifdef __has_builtin
+# define FMT_HAS_BUILTIN(x) __has_builtin(x)
+#else
+# define FMT_HAS_BUILTIN(x) 0
+#endif
+
+#ifdef __GNUC__
+# if FMT_GCC_VERSION >= 406
+#  pragma GCC diagnostic push
+
+// Disable the warning about declaration shadowing because it affects too
+// many valid cases.
+#  pragma GCC diagnostic ignored "-Wshadow"
+
+// Disable the warning about implicit conversions that may change the sign of
+// an integer; silencing it otherwise would require many explicit casts.
+#  pragma GCC diagnostic ignored "-Wsign-conversion"
+# endif
+#endif
+
+#ifdef __clang__
+# define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
+#endif
+
+#if defined(__INTEL_COMPILER)
+# define FMT_ICC_VERSION __INTEL_COMPILER
+#elif defined(__ICL)
+# define FMT_ICC_VERSION __ICL
+#endif
+
+#if defined(__clang__) && !defined(FMT_ICC_VERSION)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+# pragma clang diagnostic ignored "-Wgnu-string-literal-operator-template"
+# pragma clang diagnostic ignored "-Wpadded"
+#endif
+
+#ifdef __GNUC_LIBSTD__
+# define FMT_GNUC_LIBSTD_VERSION (__GNUC_LIBSTD__ * 100 + __GNUC_LIBSTD_MINOR__)
+#endif
+
+#ifdef __has_cpp_attribute
+# define FMT_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+#else
+# define FMT_HAS_CPP_ATTRIBUTE(x) 0
+#endif
+
+#ifndef FMT_THROW
+# if FMT_EXCEPTIONS
+#  define FMT_THROW(x) throw x
+# else
+#  define FMT_THROW(x) assert(false)
+# endif
+#endif
+
+#ifndef FMT_USE_USER_DEFINED_LITERALS
+// For Intel's compiler both it and the system gcc/msc must support UDLs.
+# if (FMT_HAS_FEATURE(cxx_user_literals) || \
+      FMT_GCC_VERSION >= 407 || FMT_MSC_VER >= 1900) && \
+      (!defined(FMT_ICC_VERSION) || FMT_ICC_VERSION >= 1500)
+#  define FMT_USE_USER_DEFINED_LITERALS 1
+# else
+#  define FMT_USE_USER_DEFINED_LITERALS 0
+# endif
+#endif
+
+#if FMT_USE_USER_DEFINED_LITERALS && \
+    (FMT_GCC_VERSION >= 600 || \
+    (defined(FMT_CLANG_VERSION) && FMT_CLANG_VERSION >= 304))
+# define FMT_UDL_TEMPLATE 1
+#else
+# define FMT_UDL_TEMPLATE 0
+#endif
+
+#ifndef FMT_USE_EXTERN_TEMPLATES
+# ifndef FMT_HEADER_ONLY
+#  define FMT_USE_EXTERN_TEMPLATES \
+     (FMT_CLANG_VERSION >= 209 || (FMT_GCC_VERSION >= 303 && FMT_HAS_GXX_CXX11))
+# else
+#  define FMT_USE_EXTERN_TEMPLATES 0
+# endif
+#endif
+
+#if FMT_HAS_GXX_CXX11 || FMT_HAS_FEATURE(cxx_trailing_return) || FMT_MSC_VER >= 1600
+# define FMT_USE_TRAILING_RETURN 1
+#endif
+
+// __builtin_clz is broken in clang with Microsoft CodeGen:
+// https://github.com/fmtlib/fmt/issues/519
+#ifndef _MSC_VER
+# if FMT_GCC_VERSION >= 400 || FMT_HAS_BUILTIN(__builtin_clz)
+#  define FMT_BUILTIN_CLZ(n) __builtin_clz(n)
+# endif
+
+# if FMT_GCC_VERSION >= 400 || FMT_HAS_BUILTIN(__builtin_clzll)
+#  define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
+# endif
+#endif
+
+// A workaround for gcc 4.4 that doesn't support union members with ctors.
+#if FMT_GCC_VERSION && FMT_GCC_VERSION <= 404
+# define FMT_UNION struct
+#else
+# define FMT_UNION union
+#endif
+
+// Some compilers masquerade as both MSVC and GCC-likes or otherwise support
+// __builtin_clz and __builtin_clzll, so only define FMT_BUILTIN_CLZ using the
+// MSVC intrinsics if the clz and clzll builtins are not available.
+#if FMT_MSC_VER && !defined(FMT_BUILTIN_CLZLL) && !defined(_MANAGED)
+# include <intrin.h>  // _BitScanReverse, _BitScanReverse64
+
+namespace fmt {
+namespace internal {
+// Avoid Clang with Microsoft CodeGen's -Wunknown-pragmas warning.
+# ifndef __clang__
+#  pragma intrinsic(_BitScanReverse)
+# endif
+inline uint32_t clz(uint32_t x) {
+  unsigned long r = 0;
+  _BitScanReverse(&r, x);
+
+  assert(x != 0);
+  // Static analysis complains about using uninitialized data
+  // "r", but the only way that can happen is if "x" is 0,
+  // which the callers guarantee to not happen.
+# pragma warning(suppress: 6102)
+  return 31 - r;
+}
+# define FMT_BUILTIN_CLZ(n) fmt::internal::clz(n)
+
+# if defined(_WIN64) && !defined(__clang__)
+#  pragma intrinsic(_BitScanReverse64)
+# endif
+
+inline uint32_t clzll(uint64_t x) {
+  unsigned long r = 0;
+# ifdef _WIN64
+  _BitScanReverse64(&r, x);
+# else
+  // Scan the high 32 bits.
+  if (_BitScanReverse(&r, static_cast<uint32_t>(x >> 32)))
+    return 63 - (r + 32);
+
+  // Scan the low 32 bits.
+  _BitScanReverse(&r, static_cast<uint32_t>(x));
+# endif
+
+  assert(x != 0);
+  // Static analysis complains about using uninitialized data
+  // "r", but the only way that can happen is if "x" is 0,
+  // which the callers guarantee to not happen.
+# pragma warning(suppress: 6102)
+  return 63 - r;
+}
+# define FMT_BUILTIN_CLZLL(n) fmt::internal::clzll(n)
+}
+}
+#endif
+
+namespace fmt {
+namespace internal {
+
+// An equivalent of `*reinterpret_cast<Dest*>(&source)` that doesn't produce
+// undefined behavior (e.g. due to type aliasing).
+// Example: uint64_t d = bit_cast<uint64_t>(2.718);
+template <typename Dest, typename Source>
+inline Dest bit_cast(const Source& source) {
+  static_assert(sizeof(Dest) == sizeof(Source), "size mismatch");
+  Dest dest;
+  std::memcpy(&dest, &source, sizeof(dest));
+  return dest;
+}
+
+// An implementation of begin and end for pre-C++11 compilers such as gcc 4.
+template <typename C>
+FMT_CONSTEXPR auto begin(const C &c) -> decltype(c.begin()) {
+  return c.begin();
+}
+template <typename T, std::size_t N>
+FMT_CONSTEXPR T *begin(T (&array)[N]) FMT_NOEXCEPT { return array; }
+template <typename C>
+FMT_CONSTEXPR auto end(const C &c) -> decltype(c.end()) { return c.end(); }
+template <typename T, std::size_t N>
+FMT_CONSTEXPR T *end(T (&array)[N]) FMT_NOEXCEPT { return array + N; }
+
+// For std::result_of in gcc 4.4.
+template <typename Result>
+struct function {
+  template <typename T>
+  struct result { typedef Result type; };
+};
+
+struct dummy_int {
+  int data[2];
+  operator int() const { return 0; }
+};
+typedef std::numeric_limits<fmt::internal::dummy_int> fputil;
+
+// Dummy implementations of system functions such as signbit and ecvt called
+// if the latter are not available.
+inline dummy_int signbit(...) { return dummy_int(); }
+inline dummy_int _ecvt_s(...) { return dummy_int(); }
+inline dummy_int isinf(...) { return dummy_int(); }
+inline dummy_int _finite(...) { return dummy_int(); }
+inline dummy_int isnan(...) { return dummy_int(); }
+inline dummy_int _isnan(...) { return dummy_int(); }
+
+// A handmade floating-point number f * pow(2, e).
+struct fp {
+  uint64_t f;
+  int e;
+
+  fp(uint64_t f, int e): f(f), e(e) {}
+
+  // Constructs fp from an IEEE754 double. It is a template to prevent compile
+  // errors on platforms where double is not IEEE754.
+  template <typename Double>
+  explicit fp(Double d) {
+    // Assume double is in the format [sign][exponent][significand].
+    typedef std::numeric_limits<Double> limits;
+    const int double_size =
+      sizeof(Double) * std::numeric_limits<unsigned char>::digits;
+    // Subtract 1 to account for an implicit most significant bit in the
+    // normalized form.
+    const int significand_size = limits::digits - 1;
+    const int exponent_size = double_size - significand_size - 1;  // -1 for sign
+    const uint64_t implicit_bit = 1ull << significand_size;
+    const uint64_t significand_mask = implicit_bit - 1;
+    const uint64_t exponent_mask = (~0ull >> 1) & ~significand_mask;
+    const int exponent_bias = (1 << exponent_size) - limits::max_exponent - 1;
+    auto u = bit_cast<uint64_t>(d);
+    auto biased_e = (u & exponent_mask) >> significand_size;
+    f = u & significand_mask;
+    if (biased_e != 0)
+      f += implicit_bit;
+    else
+      biased_e = 1;  // Subnormals use biased exponent 1 (min exponent).
+    e = biased_e - exponent_bias - significand_size;
+  }
+};
+
+// Returns an fp number representing x - y. Result may not be normalized.
+inline fp operator-(fp x, fp y) {
+  FMT_ASSERT(x.f >= y.f && x.e == y.e, "invalid operands");
+  return fp(x.f - y.f, x.e);
+}
+
+// Computes an fp number r with r.f = x.f * y.f / pow(2, 32) rounded to nearest
+// with half-up tie breaking, r.e = x.e + y.e + 32. Result may not be normalized.
+fp operator*(fp x, fp y);
+
+// Compute k such that its cached power c_k = c_k.f * pow(2, c_k.e) satisfies
+// min_exponent <= c_k.e + e <= min_exponent + 3.
+inline int compute_cached_power_index(int e, int min_exponent) {
+  constexpr double one_over_log2_10 = 0.30102999566398114;  // 1 / log2(10)
+  return static_cast<int>(std::ceil((min_exponent - e + 63) * one_over_log2_10));
+}
+
+template <typename Allocator>
+typename Allocator::value_type *allocate(Allocator& alloc, std::size_t n) {
+#if __cplusplus >= 201103L || FMT_MSC_VER >= 1700
+  return std::allocator_traits<Allocator>::allocate(alloc, n);
+#else
+  return alloc.allocate(n);
+#endif
+}
+
+// A helper function to suppress bogus "conditional expression is constant"
+// warnings.
+template <typename T>
+inline T const_check(T value) { return value; }
+}  // namespace internal
+}  // namespace fmt
+
+namespace std {
+// Standard permits specialization of std::numeric_limits. This specialization
+// is used to resolve ambiguity between isinf and std::isinf in glibc:
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48891
+// and the same for isnan and signbit.
+template <>
+class numeric_limits<fmt::internal::dummy_int> :
+    public std::numeric_limits<int> {
+ public:
+  // Portable version of isinf.
+  template <typename T>
+  static bool isinfinity(T x) {
+    using namespace fmt::internal;
+    // The resolution "priority" is:
+    // isinf macro > std::isinf > ::isinf > fmt::internal::isinf
+    if (const_check(sizeof(isinf(x)) != sizeof(fmt::internal::dummy_int)))
+      return isinf(x) != 0;
+    return !_finite(static_cast<double>(x));
+  }
+
+  // Portable version of isnan.
+  template <typename T>
+  static bool isnotanumber(T x) {
+    using namespace fmt::internal;
+    if (const_check(sizeof(isnan(x)) != sizeof(fmt::internal::dummy_int)))
+      return isnan(x) != 0;
+    return _isnan(static_cast<double>(x)) != 0;
+  }
+
+  // Portable version of signbit.
+  static bool isnegative(double x) {
+    using namespace fmt::internal;
+    if (const_check(sizeof(signbit(x)) != sizeof(fmt::internal::dummy_int)))
+      return signbit(x) != 0;
+    if (x < 0) return true;
+    if (!isnotanumber(x)) return false;
+    int dec = 0, sign = 0;
+    char buffer[2];  // The buffer size must be >= 2 or _ecvt_s will fail.
+    _ecvt_s(buffer, sizeof(buffer), x, 0, &dec, &sign);
+    return sign != 0;
+  }
+};
+}  // namespace std
+
+namespace fmt {
+
+template <typename Range>
+class basic_writer;
+
+/** A formatting error such as invalid format string. */
+class format_error : public std::runtime_error {
+ public:
+  explicit format_error(const char *message)
+  : std::runtime_error(message) {}
+
+  explicit format_error(const std::string &message)
+  : std::runtime_error(message) {}
+
+  FMT_API ~format_error() throw();
+};
+
+namespace internal {
+
+// Casts nonnegative integer to unsigned.
+template <typename Int>
+FMT_CONSTEXPR typename std::make_unsigned<Int>::type to_unsigned(Int value) {
+  FMT_ASSERT(value >= 0, "negative value");
+  return static_cast<typename std::make_unsigned<Int>::type>(value);
+}
+
+#if FMT_SECURE_SCL
+template <typename T>
+struct checked { typedef stdext::checked_array_iterator<T*> type; };
+
+// Make a checked iterator to avoid warnings on MSVC.
+template <typename T>
+inline stdext::checked_array_iterator<T*> make_checked(T *p, std::size_t size) {
+  return {p, size};
+}
+#else
+template <typename T>
+struct checked { typedef T *type; };
+template <typename T>
+inline T *make_checked(T *p, std::size_t) { return p; }
+#endif
+
+template <typename T>
+template <typename U>
+void basic_buffer<T>::append(const U *begin, const U *end) {
+  std::size_t new_size = size_ + internal::to_unsigned(end - begin);
+  reserve(new_size);
+  std::uninitialized_copy(begin, end,
+                          internal::make_checked(ptr_, capacity_) + size_);
+  size_ = new_size;
+}
+}  // namespace internal
+
+// A wrapper around std::locale used to reduce compile times since <locale>
+// is very heavy.
+class locale;
+
+class locale_provider {
+ public:
+  virtual ~locale_provider() {}
+  virtual fmt::locale locale();
+};
+
+// The number of characters to store in the basic_memory_buffer object itself
+// to avoid dynamic memory allocation.
+enum { inline_buffer_size = 500 };
+
+/**
+  \rst
+  A dynamically growing memory buffer for trivially copyable/constructible types
+  with the first ``SIZE`` elements stored in the object itself.
+
+  You can use one of the following typedefs for common character types:
+
+  +----------------+------------------------------+
+  | Type           | Definition                   |
+  +================+==============================+
+  | memory_buffer  | basic_memory_buffer<char>    |
+  +----------------+------------------------------+
+  | wmemory_buffer | basic_memory_buffer<wchar_t> |
+  +----------------+------------------------------+
+
+  **Example**::
+
+     fmt::memory_buffer out;
+     format_to(out, "The answer is {}.", 42);
+
+  This will write the following output to the ``out`` object:
+
+  .. code-block:: none
+
+     The answer is 42.
+
+  The output can be converted to an ``std::string`` with ``to_string(out)``.
+  \endrst
+ */
+template <typename T, std::size_t SIZE = inline_buffer_size,
+          typename Allocator = std::allocator<T> >
+class basic_memory_buffer: private Allocator, public internal::basic_buffer<T> {
+ private:
+  T store_[SIZE];
+
+  // Deallocate memory allocated by the buffer.
+  void deallocate() {
+    T* data = this->data();
+    if (data != store_) Allocator::deallocate(data, this->capacity());
+  }
+
+ protected:
+  void grow(std::size_t size) FMT_OVERRIDE;
+
+ public:
+  explicit basic_memory_buffer(const Allocator &alloc = Allocator())
+      : Allocator(alloc) {
+    this->set(store_, SIZE);
+  }
+  ~basic_memory_buffer() { deallocate(); }
+
+ private:
+  // Move data from other to this buffer.
+  void move(basic_memory_buffer &other) {
+    Allocator &this_alloc = *this, &other_alloc = other;
+    this_alloc = std::move(other_alloc);
+    T* data = other.data();
+    std::size_t size = other.size(), capacity = other.capacity();
+    if (data == other.store_) {
+      this->set(store_, capacity);
+      std::uninitialized_copy(other.store_, other.store_ + size,
+                              internal::make_checked(store_, capacity));
+    } else {
+      this->set(data, capacity);
+      // Set pointer to the inline array so that delete is not called
+      // when deallocating.
+      other.set(other.store_, 0);
+    }
+    this->resize(size);
+  }
+
+ public:
+  /**
+    \rst
+    Constructs a :class:`fmt::basic_memory_buffer` object moving the content
+    of the other object to it.
+    \endrst
+   */
+  basic_memory_buffer(basic_memory_buffer &&other) {
+    move(other);
+  }
+
+  /**
+    \rst
+    Moves the content of the other ``basic_memory_buffer`` object to this one.
+    \endrst
+   */
+  basic_memory_buffer &operator=(basic_memory_buffer &&other) {
+    assert(this != &other);
+    deallocate();
+    move(other);
+    return *this;
+  }
+
+  // Returns a copy of the allocator associated with this buffer.
+  Allocator get_allocator() const { return *this; }
+};
+
+template <typename T, std::size_t SIZE, typename Allocator>
+void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
+  std::size_t old_capacity = this->capacity();
+  std::size_t new_capacity = old_capacity + old_capacity / 2;
+  if (size > new_capacity)
+      new_capacity = size;
+  T *old_data = this->data();
+  T *new_data = internal::allocate<Allocator>(*this, new_capacity);
+  // The following code doesn't throw, so the raw pointer above doesn't leak.
+  std::uninitialized_copy(old_data, old_data + this->size(),
+                          internal::make_checked(new_data, new_capacity));
+  this->set(new_data, new_capacity);
+  // deallocate must not throw according to the standard, but even if it does,
+  // the buffer already uses the new storage and will deallocate it in
+  // destructor.
+  if (old_data != store_)
+    Allocator::deallocate(old_data, old_capacity);
+}
+
+typedef basic_memory_buffer<char> memory_buffer;
+typedef basic_memory_buffer<wchar_t> wmemory_buffer;
+
+/**
+  \rst
+  A fixed-size memory buffer. For a dynamically growing buffer use
+  :class:`fmt::basic_memory_buffer`.
+
+  Trying to increase the buffer size past the initial capacity will throw
+  ``std::runtime_error``.
+  \endrst
+ */
+template <typename Char>
+class basic_fixed_buffer : public internal::basic_buffer<Char> {
+ public:
+  /**
+   \rst
+   Constructs a :class:`fmt::basic_fixed_buffer` object for *array* of the
+   given size.
+   \endrst
+   */
+  basic_fixed_buffer(Char *array, std::size_t size) {
+    this->set(array, size);
+  }
+
+  /**
+   \rst
+   Constructs a :class:`fmt::basic_fixed_buffer` object for *array* of the
+   size known at compile time.
+   \endrst
+   */
+  template <std::size_t SIZE>
+  explicit basic_fixed_buffer(Char (&array)[SIZE]) {
+    this->set(array, SIZE);
+  }
+
+ protected:
+  FMT_API void grow(std::size_t size) FMT_OVERRIDE;
+};
+
+namespace internal {
+
+template <typename Char>
+struct char_traits;
+
+template <>
+struct char_traits<char> {
+  // Formats a floating-point number.
+  template <typename T>
+  FMT_API static int format_float(char *buffer, std::size_t size,
+      const char *format, unsigned width, int precision, T value);
+};
+
+template <>
+struct char_traits<wchar_t> {
+  template <typename T>
+  FMT_API static int format_float(wchar_t *buffer, std::size_t size,
+      const wchar_t *format, unsigned width, int precision, T value);
+};
+
+#if FMT_USE_EXTERN_TEMPLATES
+extern template int char_traits<char>::format_float<double>(
+    char *buffer, std::size_t size, const char* format, unsigned width,
+    int precision, double value);
+extern template int char_traits<char>::format_float<long double>(
+    char *buffer, std::size_t size, const char* format, unsigned width,
+    int precision, long double value);
+
+extern template int char_traits<wchar_t>::format_float<double>(
+    wchar_t *buffer, std::size_t size, const wchar_t* format, unsigned width,
+    int precision, double value);
+extern template int char_traits<wchar_t>::format_float<long double>(
+    wchar_t *buffer, std::size_t size, const wchar_t* format, unsigned width,
+    int precision, long double value);
+#endif
+
+template <typename Container>
+inline typename std::enable_if<
+  is_contiguous<Container>::value,
+  typename checked<typename Container::value_type>::type>::type
+    reserve(std::back_insert_iterator<Container> &it, std::size_t n) {
+  Container &c = internal::get_container(it);
+  std::size_t size = c.size();
+  c.resize(size + n);
+  return make_checked(&c[size], n);
+}
+
+template <typename Iterator>
+inline Iterator &reserve(Iterator &it, std::size_t) { return it; }
+
+template <typename Char>
+class null_terminating_iterator;
+
+template <typename Char>
+FMT_CONSTEXPR_DECL const Char *pointer_from(null_terminating_iterator<Char> it);
+
+// An iterator that produces a null terminator on *end. This simplifies parsing
+// and allows comparing the performance of processing a null-terminated string
+// vs string_view.
+template <typename Char>
+class null_terminating_iterator {
+ public:
+  typedef std::ptrdiff_t difference_type;
+  typedef Char value_type;
+  typedef const Char* pointer;
+  typedef const Char& reference;
+  typedef std::random_access_iterator_tag iterator_category;
+
+  null_terminating_iterator() : ptr_(0), end_(0) {}
+
+  FMT_CONSTEXPR null_terminating_iterator(const Char *ptr, const Char *end)
+    : ptr_(ptr), end_(end) {}
+
+  template <typename Range>
+  FMT_CONSTEXPR explicit null_terminating_iterator(const Range &r)
+    : ptr_(r.begin()), end_(r.end()) {}
+
+  null_terminating_iterator &operator=(const Char *ptr) {
+    assert(ptr <= end_);
+    ptr_ = ptr;
+    return *this;
+  }
+
+  FMT_CONSTEXPR Char operator*() const {
+    return ptr_ != end_ ? *ptr_ : 0;
+  }
+
+  FMT_CONSTEXPR null_terminating_iterator operator++() {
+    ++ptr_;
+    return *this;
+  }
+
+  FMT_CONSTEXPR null_terminating_iterator operator++(int) {
+    null_terminating_iterator result(*this);
+    ++ptr_;
+    return result;
+  }
+
+  FMT_CONSTEXPR null_terminating_iterator operator--() {
+    --ptr_;
+    return *this;
+  }
+
+  FMT_CONSTEXPR null_terminating_iterator operator+(difference_type n) {
+    return null_terminating_iterator(ptr_ + n, end_);
+  }
+
+  FMT_CONSTEXPR null_terminating_iterator operator-(difference_type n) {
+    return null_terminating_iterator(ptr_ - n, end_);
+  }
+
+  FMT_CONSTEXPR null_terminating_iterator operator+=(difference_type n) {
+    ptr_ += n;
+    return *this;
+  }
+
+  FMT_CONSTEXPR difference_type operator-(
+      null_terminating_iterator other) const {
+    return ptr_ - other.ptr_;
+  }
+
+  FMT_CONSTEXPR bool operator!=(null_terminating_iterator other) const {
+    return ptr_ != other.ptr_;
+  }
+
+  bool operator>=(null_terminating_iterator other) const {
+    return ptr_ >= other.ptr_;
+  }
+
+  // This should be a friend specialization pointer_from<Char> but the latter
+  // doesn't compile by gcc 5.1 due to a compiler bug.
+  template <typename CharT>
+  friend FMT_CONSTEXPR_DECL const CharT *pointer_from(
+      null_terminating_iterator<CharT> it);
+
+ private:
+  const Char *ptr_;
+  const Char *end_;
+};
+
+template <typename T>
+FMT_CONSTEXPR const T *pointer_from(const T *p) { return p; }
+
+template <typename Char>
+FMT_CONSTEXPR const Char *pointer_from(null_terminating_iterator<Char> it) {
+  return it.ptr_;
+}
+
+// An output iterator that counts the number of objects written to it and
+// discards them.
+template <typename T>
+class counting_iterator {
+ private:
+  std::size_t count_;
+  mutable T blackhole_;
+
+ public:
+  typedef std::output_iterator_tag iterator_category;
+  typedef T value_type;
+  typedef std::ptrdiff_t difference_type;
+  typedef T* pointer;
+  typedef T& reference;
+  typedef counting_iterator _Unchecked_type;  // Mark iterator as checked.
+
+  counting_iterator(): count_(0) {}
+
+  std::size_t count() const { return count_; }
+
+  counting_iterator& operator++() {
+    ++count_;
+    return *this;
+  }
+
+  counting_iterator operator++(int) { return ++*this; }
+
+  T &operator*() const { return blackhole_; }
+};
+
+// An output iterator that truncates the output and counts the number of objects
+// written to it.
+template <typename OutputIt>
+class truncating_iterator {
+ private:
+  typedef std::iterator_traits<OutputIt> traits;
+
+  OutputIt out_;
+  std::size_t limit_;
+  std::size_t count_;
+  mutable typename traits::value_type blackhole_;
+
+ public:
+  typedef std::output_iterator_tag iterator_category;
+  typedef typename traits::value_type value_type;
+  typedef typename traits::difference_type difference_type;
+  typedef typename traits::pointer pointer;
+  typedef typename traits::reference reference;
+  typedef truncating_iterator _Unchecked_type;  // Mark iterator as checked.
+
+  truncating_iterator(OutputIt out, std::size_t limit)
+    : out_(out), limit_(limit), count_(0) {}
+
+  OutputIt base() const { return out_; }
+  std::size_t count() const { return count_; }
+
+  truncating_iterator& operator++() {
+    if (count_++ < limit_)
+      ++out_;
+    return *this;
+  }
+
+  truncating_iterator operator++(int) { return ++*this; }
+
+  reference operator*() const { return count_ < limit_ ? *out_ : blackhole_; }
+};
+
+// Returns true if value is negative, false otherwise.
+// Same as (value < 0) but doesn't produce warnings if T is an unsigned type.
+template <typename T>
+FMT_CONSTEXPR typename std::enable_if<
+    std::numeric_limits<T>::is_signed, bool>::type is_negative(T value) {
+  return value < 0;
+}
+template <typename T>
+FMT_CONSTEXPR typename std::enable_if<
+    !std::numeric_limits<T>::is_signed, bool>::type is_negative(T) {
+  return false;
+}
+
+template <typename T>
+struct int_traits {
+  // Smallest of uint32_t and uint64_t that is large enough to represent
+  // all values of T.
+  typedef typename std::conditional<
+    std::numeric_limits<T>::digits <= 32, uint32_t, uint64_t>::type main_type;
+};
+
+// Static data is placed in this class template to allow header-only
+// configuration.
+template <typename T = void>
+struct FMT_API basic_data {
+  static const uint32_t POWERS_OF_10_32[];
+  static const uint64_t POWERS_OF_10_64[];
+  static const uint64_t POW10_SIGNIFICANDS[];
+  static const int16_t POW10_EXPONENTS[];
+  static const char DIGITS[];
+};
+
+#if FMT_USE_EXTERN_TEMPLATES
+extern template struct basic_data<void>;
+#endif
+
+typedef basic_data<> data;
+
+#ifdef FMT_BUILTIN_CLZLL
+// Returns the number of decimal digits in n. Leading zeros are not counted
+// except for n == 0 in which case count_digits returns 1.
+inline unsigned count_digits(uint64_t n) {
+  // Based on http://graphics.stanford.edu/~seander/bithacks.html#IntegerLog10
+  // and the benchmark https://github.com/localvoid/cxx-benchmark-count-digits.
+  int t = (64 - FMT_BUILTIN_CLZLL(n | 1)) * 1233 >> 12;
+  return to_unsigned(t) - (n < data::POWERS_OF_10_64[t]) + 1;
+}
+#else
+// Fallback version of count_digits used when __builtin_clz is not available.
+inline unsigned count_digits(uint64_t n) {
+  unsigned count = 1;
+  for (;;) {
+    // Integer division is slow so do it for a group of four digits instead
+    // of for every digit. The idea comes from the talk by Alexandrescu
+    // "Three Optimization Tips for C++". See speed-test for a comparison.
+    if (n < 10) return count;
+    if (n < 100) return count + 1;
+    if (n < 1000) return count + 2;
+    if (n < 10000) return count + 3;
+    n /= 10000u;
+    count += 4;
+  }
+}
+#endif
+
+#if FMT_HAS_CPP_ATTRIBUTE(always_inline)
+# define FMT_ALWAYS_INLINE __attribute__((always_inline))
+#else
+# define FMT_ALWAYS_INLINE
+#endif
+
+template <typename Handler>
+inline char *lg(uint32_t n, Handler h) FMT_ALWAYS_INLINE;
+
+// Computes g = floor(log10(n)) and calls h.on<g>(n);
+template <typename Handler>
+inline char *lg(uint32_t n, Handler h) {
+  return n < 100 ? n < 10 ? h.template on<0>(n) : h.template on<1>(n)
+                 : n < 1000000
+                       ? n < 10000 ? n < 1000 ? h.template on<2>(n)
+                                              : h.template on<3>(n)
+                                   : n < 100000 ? h.template on<4>(n)
+                                                : h.template on<5>(n)
+                       : n < 100000000 ? n < 10000000 ? h.template on<6>(n)
+                                                      : h.template on<7>(n)
+                                       : n < 1000000000 ? h.template on<8>(n)
+                                                        : h.template on<9>(n);
+}
+
+// An lg handler that formats a decimal number.
+// Usage: lg(n, decimal_formatter(buffer));
+class decimal_formatter {
+ private:
+  char *buffer_;
+
+  void write_pair(unsigned N, uint32_t index) {
+    std::memcpy(buffer_ + N, data::DIGITS + index * 2, 2);
+  }
+
+ public:
+  explicit decimal_formatter(char *buf) : buffer_(buf) {}
+
+  template <unsigned N> char *on(uint32_t u) {
+    if (N == 0) {
+      *buffer_ = static_cast<char>(u) + '0';
+    } else if (N == 1) {
+      write_pair(0, u);
+    } else {
+      // The idea of using 4.32 fixed-point numbers is based on
+      // https://github.com/jeaiii/itoa
+      unsigned n = N - 1;
+      unsigned a = n / 5 * n * 53 / 16;
+      uint64_t t = ((1ULL << (32 + a)) / data::POWERS_OF_10_32[n] + 1 - n / 9);
+      t = ((t * u) >> a) + n / 5 * 4;
+      write_pair(0, t >> 32);
+      for (int i = 2; i < N; i += 2) {
+        t = 100ULL * static_cast<uint32_t>(t);
+        write_pair(i, t >> 32);
+      }
+      if (N % 2 == 0) {
+        buffer_[N] = static_cast<char>(
+          (10ULL * static_cast<uint32_t>(t)) >> 32) + '0';
+      }
+    }
+    return buffer_ += N + 1;
+  }
+};
+
+// An lg handler that formats a decimal number with a terminating null.
+class decimal_formatter_null : public decimal_formatter {
+ public:
+  explicit decimal_formatter_null(char *buf) : decimal_formatter(buf) {}
+
+  template <unsigned N> char *on(uint32_t u) {
+    char *buf = decimal_formatter::on<N>(u);
+    *buf = '\0';
+    return buf;
+  }
+};
+
+#ifdef FMT_BUILTIN_CLZ
+// Optional version of count_digits for better performance on 32-bit platforms.
+inline unsigned count_digits(uint32_t n) {
+  int t = (32 - FMT_BUILTIN_CLZ(n | 1)) * 1233 >> 12;
+  return to_unsigned(t) - (n < data::POWERS_OF_10_32[t]) + 1;
+}
+#endif
+
+// A functor that doesn't add a thousands separator.
+struct no_thousands_sep {
+  typedef char char_type;
+
+  template <typename Char>
+  void operator()(Char *) {}
+};
+
+// A functor that adds a thousands separator.
+template <typename Char>
+class add_thousands_sep {
+ private:
+  basic_string_view<Char> sep_;
+
+  // Index of a decimal digit with the least significant digit having index 0.
+  unsigned digit_index_;
+
+ public:
+  typedef Char char_type;
+
+  explicit add_thousands_sep(basic_string_view<Char> sep)
+    : sep_(sep), digit_index_(0) {}
+
+  void operator()(Char *&buffer) {
+    if (++digit_index_ % 3 != 0)
+      return;
+    buffer -= sep_.size();
+    std::uninitialized_copy(sep_.data(), sep_.data() + sep_.size(),
+                            internal::make_checked(buffer, sep_.size()));
+  }
+};
+
+template <typename Char>
+FMT_API Char thousands_sep(locale_provider *lp);
+
+// Formats a decimal unsigned integer value writing into buffer.
+// thousands_sep is a functor that is called after writing each char to
+// add a thousands separator if necessary.
+template <typename UInt, typename Char, typename ThousandsSep>
+inline Char *format_decimal(Char *buffer, UInt value, unsigned num_digits,
+                            ThousandsSep thousands_sep) {
+  buffer += num_digits;
+  Char *end = buffer;
+  while (value >= 100) {
+    // Integer division is slow so do it for a group of two digits instead
+    // of for every digit. The idea comes from the talk by Alexandrescu
+    // "Three Optimization Tips for C++". See speed-test for a comparison.
+    unsigned index = static_cast<unsigned>((value % 100) * 2);
+    value /= 100;
+    *--buffer = data::DIGITS[index + 1];
+    thousands_sep(buffer);
+    *--buffer = data::DIGITS[index];
+    thousands_sep(buffer);
+  }
+  if (value < 10) {
+    *--buffer = static_cast<char>('0' + value);
+    return end;
+  }
+  unsigned index = static_cast<unsigned>(value * 2);
+  *--buffer = data::DIGITS[index + 1];
+  thousands_sep(buffer);
+  *--buffer = data::DIGITS[index];
+  return end;
+}
+
+template <typename UInt, typename Iterator, typename ThousandsSep>
+inline Iterator format_decimal(
+    Iterator out, UInt value, unsigned num_digits, ThousandsSep sep) {
+  typedef typename ThousandsSep::char_type char_type;
+  // Buffer should be large enough to hold all digits (digits10 + 1) and null.
+  char_type buffer[std::numeric_limits<UInt>::digits10 + 2];
+  format_decimal(buffer, value, num_digits, sep);
+  return std::copy_n(buffer, num_digits, out);
+}
+
+template <typename It, typename UInt>
+inline It format_decimal(It out, UInt value, unsigned num_digits) {
+  return format_decimal(out, value, num_digits, no_thousands_sep());
+}
+
+template <unsigned BASE_BITS, typename Char, typename UInt>
+inline Char *format_uint(Char *buffer, UInt value, unsigned num_digits,
+                         bool upper = false) {
+  buffer += num_digits;
+  Char *end = buffer;
+  do {
+    const char *digits = upper ? "0123456789ABCDEF" : "0123456789abcdef";
+    unsigned digit = (value & ((1 << BASE_BITS) - 1));
+    *--buffer = BASE_BITS < 4 ? static_cast<char>('0' + digit) : digits[digit];
+  } while ((value >>= BASE_BITS) != 0);
+  return end;
+}
+
+template <unsigned BASE_BITS, typename It, typename UInt>
+inline It format_uint(It out, UInt value, unsigned num_digits,
+                      bool upper = false) {
+  // Buffer should be large enough to hold all digits (digits / BASE_BITS + 1)
+  // and null.
+  char buffer[std::numeric_limits<UInt>::digits / BASE_BITS + 2];
+  format_uint<BASE_BITS>(buffer, value, num_digits, upper);
+  return std::copy_n(buffer, num_digits, out);
+}
+
+#ifndef _WIN32
+# define FMT_USE_WINDOWS_H 0
+#elif !defined(FMT_USE_WINDOWS_H)
+# define FMT_USE_WINDOWS_H 1
+#endif
+
+// Define FMT_USE_WINDOWS_H to 0 to disable use of windows.h.
+// All the functionality that relies on it will be disabled too.
+#if FMT_USE_WINDOWS_H
+// A converter from UTF-8 to UTF-16.
+// It is only provided for Windows since other systems support UTF-8 natively.
+class utf8_to_utf16 {
+ private:
+  wmemory_buffer buffer_;
+
+ public:
+  FMT_API explicit utf8_to_utf16(string_view s);
+  operator wstring_view() const { return wstring_view(&buffer_[0], size()); }
+  size_t size() const { return buffer_.size() - 1; }
+  const wchar_t *c_str() const { return &buffer_[0]; }
+  std::wstring str() const { return std::wstring(&buffer_[0], size()); }
+};
+
+// A converter from UTF-16 to UTF-8.
+// It is only provided for Windows since other systems support UTF-8 natively.
+class utf16_to_utf8 {
+ private:
+  memory_buffer buffer_;
+
+ public:
+  utf16_to_utf8() {}
+  FMT_API explicit utf16_to_utf8(wstring_view s);
+  operator string_view() const { return string_view(&buffer_[0], size()); }
+  size_t size() const { return buffer_.size() - 1; }
+  const char *c_str() const { return &buffer_[0]; }
+  std::string str() const { return std::string(&buffer_[0], size()); }
+
+  // Performs conversion returning a system error code instead of
+  // throwing exception on conversion error. This method may still throw
+  // in case of memory allocation error.
+  FMT_API int convert(wstring_view s);
+};
+
+FMT_API void format_windows_error(fmt::internal::buffer &out, int error_code,
+                                  fmt::string_view message) FMT_NOEXCEPT;
+#endif
+
+template <typename T = void>
+struct null {};
+}  // namespace internal
+
+struct monostate {};
+
+/**
+  \rst
+  Visits an argument dispatching to the appropriate visit method based on
+  the argument type. For example, if the argument type is ``double`` then
+  ``vis(value)`` will be called with the value of type ``double``.
+  \endrst
+ */
+template <typename Visitor, typename Context>
+FMT_CONSTEXPR typename internal::result_of<Visitor(int)>::type
+    visit(Visitor &&vis, basic_format_arg<Context> arg) {
+  typedef typename Context::char_type char_type;
+  switch (arg.type_) {
+  case internal::none_type:
+    break;
+  case internal::name_arg_type:
+    FMT_ASSERT(false, "invalid argument type");
+    break;
+  case internal::int_type:
+    return vis(arg.value_.int_value);
+  case internal::uint_type:
+    return vis(arg.value_.uint_value);
+  case internal::long_long_type:
+    return vis(arg.value_.long_long_value);
+  case internal::ulong_long_type:
+    return vis(arg.value_.ulong_long_value);
+  case internal::bool_type:
+    return vis(arg.value_.int_value != 0);
+  case internal::char_type:
+    return vis(static_cast<char_type>(arg.value_.int_value));
+  case internal::double_type:
+    return vis(arg.value_.double_value);
+  case internal::long_double_type:
+    return vis(arg.value_.long_double_value);
+  case internal::cstring_type:
+    return vis(arg.value_.string.value);
+  case internal::string_type:
+    return vis(basic_string_view<char_type>(
+                 arg.value_.string.value, arg.value_.string.size));
+  case internal::pointer_type:
+    return vis(arg.value_.pointer);
+  case internal::custom_type:
+    return vis(typename basic_format_arg<Context>::handle(arg.value_.custom));
+  }
+  return vis(monostate());
+}
+
+enum alignment {
+  ALIGN_DEFAULT, ALIGN_LEFT, ALIGN_RIGHT, ALIGN_CENTER, ALIGN_NUMERIC
+};
+
+// Flags.
+enum {SIGN_FLAG = 1, PLUS_FLAG = 2, MINUS_FLAG = 4, HASH_FLAG = 8};
+
+enum format_spec_tag {fill_tag, align_tag, width_tag, type_tag};
+
+// Format specifier.
+template <typename T, format_spec_tag>
+class format_spec {
+ private:
+  T value_;
+
+ public:
+  typedef T value_type;
+
+  explicit format_spec(T value) : value_(value) {}
+
+  T value() const { return value_; }
+};
+
+// template <typename Char>
+// typedef format_spec<Char, fill_tag> fill_spec;
+template <typename Char>
+class fill_spec : public format_spec<Char, fill_tag> {
+ public:
+  explicit fill_spec(Char value) : format_spec<Char, fill_tag>(value) {}
+};
+
+typedef format_spec<unsigned, width_tag> width_spec;
+typedef format_spec<char, type_tag> type_spec;
+
+// An empty format specifier.
+struct empty_spec {};
+
+// An alignment specifier.
+struct align_spec : empty_spec {
+  unsigned width_;
+  // Fill is always wchar_t and cast to char if necessary to avoid having
+  // two specialization of AlignSpec and its subclasses.
+  wchar_t fill_;
+  alignment align_;
+
+  FMT_CONSTEXPR align_spec(
+      unsigned width, wchar_t fill, alignment align = ALIGN_DEFAULT)
+  : width_(width), fill_(fill), align_(align) {}
+
+  FMT_CONSTEXPR unsigned width() const { return width_; }
+  FMT_CONSTEXPR wchar_t fill() const { return fill_; }
+  FMT_CONSTEXPR alignment align() const { return align_; }
+
+  int precision() const { return -1; }
+};
+
+// Format specifiers.
+template <typename Char>
+class basic_format_specs : public align_spec {
+ private:
+  template <typename FillChar>
+  typename std::enable_if<std::is_same<FillChar, Char>::value ||
+                          std::is_same<FillChar, char>::value, void>::type
+      set(fill_spec<FillChar> fill) {
+    fill_ = fill.value();
+  }
+
+  void set(width_spec width) {
+    width_ = width.value();
+  }
+
+  void set(type_spec type) {
+    type_ = type.value();
+  }
+
+  template <typename Spec, typename... Specs>
+  void set(Spec spec, Specs... tail) {
+    set(spec);
+    set(tail...);
+  }
+
+ public:
+  unsigned flags_;
+  int precision_;
+  Char type_;
+
+  FMT_CONSTEXPR basic_format_specs(
+      unsigned width = 0, char type = 0, wchar_t fill = ' ')
+  : align_spec(width, fill), flags_(0), precision_(-1), type_(type) {}
+
+  template <typename... FormatSpecs>
+  explicit basic_format_specs(FormatSpecs... specs)
+    : align_spec(0, ' '), flags_(0), precision_(-1), type_(0) {
+    set(specs...);
+  }
+
+  FMT_CONSTEXPR bool flag(unsigned f) const { return (flags_ & f) != 0; }
+  FMT_CONSTEXPR int precision() const { return precision_; }
+  FMT_CONSTEXPR Char type() const { return type_; }
+};
+
+typedef basic_format_specs<char> format_specs;
+
+template <typename Char, typename ErrorHandler>
+FMT_CONSTEXPR unsigned basic_parse_context<Char, ErrorHandler>::next_arg_id() {
+  if (next_arg_id_ >= 0)
+    return internal::to_unsigned(next_arg_id_++);
+  on_error("cannot switch from manual to automatic argument indexing");
+  return 0;
+}
+
+struct format_string {};
+
+namespace internal {
+
+template <typename Char, typename Handler>
+FMT_CONSTEXPR void handle_int_type_spec(Char spec, Handler &&handler) {
+  switch (spec) {
+  case 0: case 'd':
+    handler.on_dec();
+    break;
+  case 'x': case 'X':
+    handler.on_hex();
+    break;
+  case 'b': case 'B':
+    handler.on_bin();
+    break;
+  case 'o':
+    handler.on_oct();
+    break;
+  case 'n':
+    handler.on_num();
+    break;
+  default:
+    handler.on_error();
+  }
+}
+
+template <typename Char, typename Handler>
+FMT_CONSTEXPR void handle_float_type_spec(Char spec, Handler &&handler) {
+  switch (spec) {
+  case 0: case 'g': case 'G':
+    handler.on_general();
+    break;
+  case 'e': case 'E':
+    handler.on_exp();
+    break;
+  case 'f': case 'F':
+    handler.on_fixed();
+    break;
+   case 'a': case 'A':
+    handler.on_hex();
+    break;
+  default:
+    handler.on_error();
+    break;
+  }
+}
+
+template <typename Char, typename Handler>
+FMT_CONSTEXPR void handle_char_specs(
+    const basic_format_specs<Char> &specs, Handler &&handler) {
+  if (specs.type() && specs.type() != 'c') {
+    handler.on_int();
+    return;
+  }
+  if (specs.align() == ALIGN_NUMERIC || specs.flag(~0u) != 0)
+    handler.on_error("invalid format specifier for char");
+  handler.on_char();
+}
+
+template <typename Char, typename Handler>
+FMT_CONSTEXPR void handle_cstring_type_spec(Char spec, Handler &&handler) {
+  if (spec == 0 || spec == 's')
+    handler.on_string();
+  else if (spec == 'p')
+    handler.on_pointer();
+  else
+    handler.on_error("invalid type specifier");
+}
+
+template <typename Char, typename ErrorHandler>
+FMT_CONSTEXPR void check_string_type_spec(Char spec, ErrorHandler &&eh) {
+  if (spec != 0 && spec != 's')
+    eh.on_error("invalid type specifier");
+}
+
+template <typename Char, typename ErrorHandler>
+FMT_CONSTEXPR void check_pointer_type_spec(Char spec, ErrorHandler &&eh) {
+  if (spec != 0 && spec != 'p')
+    eh.on_error("invalid type specifier");
+}
+
+template <typename ErrorHandler>
+class int_type_checker : private ErrorHandler {
+ public:
+  FMT_CONSTEXPR explicit int_type_checker(ErrorHandler eh) : ErrorHandler(eh) {}
+
+  FMT_CONSTEXPR void on_dec() {}
+  FMT_CONSTEXPR void on_hex() {}
+  FMT_CONSTEXPR void on_bin() {}
+  FMT_CONSTEXPR void on_oct() {}
+  FMT_CONSTEXPR void on_num() {}
+
+  FMT_CONSTEXPR void on_error() {
+    ErrorHandler::on_error("invalid type specifier");
+  }
+};
+
+template <typename ErrorHandler>
+class float_type_checker : private ErrorHandler {
+ public:
+  FMT_CONSTEXPR explicit float_type_checker(ErrorHandler eh)
+    : ErrorHandler(eh) {}
+
+  FMT_CONSTEXPR void on_general() {}
+  FMT_CONSTEXPR void on_exp() {}
+  FMT_CONSTEXPR void on_fixed() {}
+  FMT_CONSTEXPR void on_hex() {}
+
+  FMT_CONSTEXPR void on_error() {
+    ErrorHandler::on_error("invalid type specifier");
+  }
+};
+
+template <typename ErrorHandler>
+class char_specs_checker : public ErrorHandler {
+ private:
+  char type_;
+
+ public:
+  FMT_CONSTEXPR char_specs_checker(char type, ErrorHandler eh)
+    : ErrorHandler(eh), type_(type) {}
+
+  FMT_CONSTEXPR void on_int() {
+    handle_int_type_spec(type_, int_type_checker<ErrorHandler>(*this));
+  }
+  FMT_CONSTEXPR void on_char() {}
+};
+
+template <typename ErrorHandler>
+class cstring_type_checker : public ErrorHandler {
+ public:
+  FMT_CONSTEXPR explicit cstring_type_checker(ErrorHandler eh)
+    : ErrorHandler(eh) {}
+
+  FMT_CONSTEXPR void on_string() {}
+  FMT_CONSTEXPR void on_pointer() {}
+};
+
+template <typename Context>
+void arg_map<Context>::init(const basic_format_args<Context> &args) {
+  if (map_)
+    return;
+  map_ = new entry[args.max_size()];
+  bool use_values = args.type(max_packed_args - 1) == internal::none_type;
+  if (use_values) {
+    for (unsigned i = 0;/*nothing*/; ++i) {
+      internal::type arg_type = args.type(i);
+      switch (arg_type) {
+        case internal::none_type:
+          return;
+        case internal::name_arg_type:
+          push_back(args.values_[i]);
+          break;
+        default:
+          break; // Do nothing.
+      }
+    }
+    return;
+  }
+  for (unsigned i = 0; i != max_packed_args; ++i) {
+    if (args.type(i) == internal::name_arg_type)
+      push_back(args.args_[i].value_);
+  }
+  for (unsigned i = max_packed_args; ; ++i) {
+    switch (args.args_[i].type_) {
+      case internal::none_type:
+        return;
+      case internal::name_arg_type:
+        push_back(args.args_[i].value_);
+        break;
+      default:
+        break; // Do nothing.
+    }
+  }
+}
+
+template <typename Range>
+class arg_formatter_base {
+ public:
+  typedef typename Range::value_type char_type;
+  typedef decltype(internal::declval<Range>().begin()) iterator;
+  typedef basic_format_specs<char_type> format_specs;
+
+ private:
+  typedef basic_writer<Range> writer_type;
+  writer_type writer_;
+  format_specs &specs_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(arg_formatter_base);
+
+  struct char_writer {
+    char_type value;
+    template <typename It>
+    void operator()(It &&it) const { *it++ = value; }
+  };
+
+  void write_char(char_type value) {
+    writer_.write_padded(1, specs_, char_writer{value});
+  }
+
+  void write_pointer(const void *p) {
+    format_specs specs = specs_;
+    specs.flags_ = HASH_FLAG;
+    specs.type_ = 'x';
+    writer_.write_int(reinterpret_cast<uintptr_t>(p), specs);
+  }
+
+ protected:
+  writer_type &writer() { return writer_; }
+  format_specs &spec() { return specs_; }
+  iterator out() { return writer_.out(); }
+
+  void write(bool value) {
+    writer_.write_str(string_view(value ? "true" : "false"), specs_);
+  }
+
+  void write(const char_type *value) {
+    if (!value)
+      FMT_THROW(format_error("string pointer is null"));
+    auto length = std::char_traits<char_type>::length(value);
+    writer_.write_str(basic_string_view<char_type>(value, length), specs_);
+  }
+
+ public:
+  arg_formatter_base(Range r, format_specs &s): writer_(r), specs_(s) {}
+
+  iterator operator()(monostate) {
+    FMT_ASSERT(false, "invalid argument type");
+    return out();
+  }
+
+  template <typename T>
+  typename std::enable_if<std::is_integral<T>::value, iterator>::type
+      operator()(T value) {
+    writer_.write_int(value, specs_);
+    return out();
+  }
+
+  template <typename T>
+  typename std::enable_if<std::is_floating_point<T>::value, iterator>::type
+      operator()(T value) {
+    writer_.write_double(value, specs_);
+    return out();
+  }
+
+  iterator operator()(bool value) {
+    if (specs_.type_)
+      return (*this)(value ? 1 : 0);
+    write(value);
+    return out();
+  }
+
+  struct char_spec_handler : internal::error_handler {
+    arg_formatter_base &formatter;
+    char_type value;
+
+    char_spec_handler(arg_formatter_base& f, char_type val)
+      : formatter(f), value(val) {}
+
+    void on_int() { formatter.writer_.write_int(value, formatter.specs_); }
+    void on_char() { formatter.write_char(value); }
+  };
+
+  iterator operator()(char_type value) {
+    internal::handle_char_specs(specs_, char_spec_handler(*this, value));
+    return out();
+  }
+
+  struct cstring_spec_handler : internal::error_handler {
+    arg_formatter_base &formatter;
+    const char_type *value;
+
+    cstring_spec_handler(arg_formatter_base &f, const char_type *val)
+      : formatter(f), value(val) {}
+
+    void on_string() { formatter.write(value); }
+    void on_pointer() { formatter.write_pointer(value); }
+  };
+
+  iterator operator()(const char_type *value) {
+    internal::handle_cstring_type_spec(
+          specs_.type_, cstring_spec_handler(*this, value));
+    return out();
+  }
+
+  iterator operator()(basic_string_view<char_type> value) {
+    internal::check_string_type_spec(specs_.type_, internal::error_handler());
+    writer_.write_str(value, specs_);
+    return out();
+  }
+
+  iterator operator()(const void *value) {
+    check_pointer_type_spec(specs_.type_, internal::error_handler());
+    write_pointer(value);
+    return out();
+  }
+};
+
+template <typename S>
+struct is_format_string:
+  std::integral_constant<bool, std::is_base_of<format_string, S>::value> {};
+
+template <typename Char>
+FMT_CONSTEXPR bool is_name_start(Char c) {
+  return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || '_' == c;
+}
+
+// Parses the input as an unsigned integer. This function assumes that the
+// first character is a digit and presence of a non-digit character at the end.
+// it: an iterator pointing to the beginning of the input range.
+template <typename Iterator, typename ErrorHandler>
+FMT_CONSTEXPR unsigned parse_nonnegative_int(Iterator &it, ErrorHandler &&eh) {
+  assert('0' <= *it && *it <= '9');
+  unsigned value = 0;
+  // Convert to unsigned to prevent a warning.
+  unsigned max_int = (std::numeric_limits<int>::max)();
+  unsigned big = max_int / 10;
+  do {
+    // Check for overflow.
+    if (value > big) {
+      value = max_int + 1;
+      break;
+    }
+    value = value * 10 + (*it - '0');
+    // Workaround for MSVC "setup_exception stack overflow" error:
+    auto next = it;
+    ++next;
+    it = next;
+  } while ('0' <= *it && *it <= '9');
+  if (value > max_int)
+    eh.on_error("number is too big");
+  return value;
+}
+
+template <typename Char, typename Context>
+class custom_formatter: public function<bool> {
+ private:
+  Context &ctx_;
+
+ public:
+  explicit custom_formatter(Context &ctx): ctx_(ctx) {}
+
+  bool operator()(typename basic_format_arg<Context>::handle h) const {
+    h.format(ctx_);
+    return true;
+  }
+
+  template <typename T>
+  bool operator()(T) const { return false; }
+};
+
+template <typename T>
+struct is_integer {
+  enum {
+    value = std::is_integral<T>::value && !std::is_same<T, bool>::value &&
+            !std::is_same<T, char>::value && !std::is_same<T, wchar_t>::value
+  };
+};
+
+template <typename ErrorHandler>
+class width_checker: public function<unsigned long long> {
+ public:
+  explicit FMT_CONSTEXPR width_checker(ErrorHandler &eh) : handler_(eh) {}
+
+  template <typename T>
+  FMT_CONSTEXPR
+  typename std::enable_if<
+      is_integer<T>::value, unsigned long long>::type operator()(T value) {
+    if (is_negative(value))
+      handler_.on_error("negative width");
+    return value;
+  }
+
+  template <typename T>
+  FMT_CONSTEXPR typename std::enable_if<
+      !is_integer<T>::value, unsigned long long>::type operator()(T) {
+    handler_.on_error("width is not integer");
+    return 0;
+  }
+
+ private:
+  ErrorHandler &handler_;
+};
+
+template <typename ErrorHandler>
+class precision_checker: public function<unsigned long long> {
+ public:
+  explicit FMT_CONSTEXPR precision_checker(ErrorHandler &eh) : handler_(eh) {}
+
+  template <typename T>
+  FMT_CONSTEXPR typename std::enable_if<
+      is_integer<T>::value, unsigned long long>::type operator()(T value) {
+    if (is_negative(value))
+      handler_.on_error("negative precision");
+    return value;
+  }
+
+  template <typename T>
+  FMT_CONSTEXPR typename std::enable_if<
+      !is_integer<T>::value, unsigned long long>::type operator()(T) {
+    handler_.on_error("precision is not integer");
+    return 0;
+  }
+
+ private:
+  ErrorHandler &handler_;
+};
+
+// A format specifier handler that sets fields in basic_format_specs.
+template <typename Char>
+class specs_setter {
+ public:
+  explicit FMT_CONSTEXPR specs_setter(basic_format_specs<Char> &specs):
+    specs_(specs) {}
+
+  FMT_CONSTEXPR specs_setter(const specs_setter &other) : specs_(other.specs_) {}
+
+  FMT_CONSTEXPR void on_align(alignment align) { specs_.align_ = align; }
+  FMT_CONSTEXPR void on_fill(Char fill) { specs_.fill_ = fill; }
+  FMT_CONSTEXPR void on_plus() { specs_.flags_ |= SIGN_FLAG | PLUS_FLAG; }
+  FMT_CONSTEXPR void on_minus() { specs_.flags_ |= MINUS_FLAG; }
+  FMT_CONSTEXPR void on_space() { specs_.flags_ |= SIGN_FLAG; }
+  FMT_CONSTEXPR void on_hash() { specs_.flags_ |= HASH_FLAG; }
+
+  FMT_CONSTEXPR void on_zero() {
+    specs_.align_ = ALIGN_NUMERIC;
+    specs_.fill_ = '0';
+  }
+
+  FMT_CONSTEXPR void on_width(unsigned width) { specs_.width_ = width; }
+  FMT_CONSTEXPR void on_precision(unsigned precision) {
+    specs_.precision_ = precision;
+  }
+  FMT_CONSTEXPR void end_precision() {}
+
+  FMT_CONSTEXPR void on_type(Char type) { specs_.type_ = type; }
+
+ protected:
+  basic_format_specs<Char> &specs_;
+};
+
+// A format specifier handler that checks if specifiers are consistent with the
+// argument type.
+template <typename Handler>
+class specs_checker : public Handler {
+ public:
+  FMT_CONSTEXPR specs_checker(const Handler& handler, internal::type arg_type)
+    : Handler(handler), arg_type_(arg_type) {}
+
+  FMT_CONSTEXPR specs_checker(const specs_checker &other)
+    : Handler(other), arg_type_(other.arg_type_) {}
+
+  FMT_CONSTEXPR void on_align(alignment align) {
+    if (align == ALIGN_NUMERIC)
+      require_numeric_argument();
+    Handler::on_align(align);
+  }
+
+  FMT_CONSTEXPR void on_plus() {
+    check_sign();
+    Handler::on_plus();
+  }
+
+  FMT_CONSTEXPR void on_minus() {
+    check_sign();
+    Handler::on_minus();
+  }
+
+  FMT_CONSTEXPR void on_space() {
+    check_sign();
+    Handler::on_space();
+  }
+
+  FMT_CONSTEXPR void on_hash() {
+    require_numeric_argument();
+    Handler::on_hash();
+  }
+
+  FMT_CONSTEXPR void on_zero() {
+    require_numeric_argument();
+    Handler::on_zero();
+  }
+
+  FMT_CONSTEXPR void end_precision() {
+    if (is_integral(arg_type_) || arg_type_ == pointer_type)
+      this->on_error("precision not allowed for this argument type");
+  }
+
+ private:
+  FMT_CONSTEXPR void require_numeric_argument() {
+    if (!is_arithmetic(arg_type_))
+      this->on_error("format specifier requires numeric argument");
+  }
+
+  FMT_CONSTEXPR void check_sign() {
+    require_numeric_argument();
+    if (is_integral(arg_type_) && arg_type_ != int_type &&
+        arg_type_ != long_long_type && arg_type_ != internal::char_type) {
+      this->on_error("format specifier requires signed argument");
+    }
+  }
+
+  internal::type arg_type_;
+};
+
+template <template <typename> class Handler, typename T,
+          typename Context, typename ErrorHandler>
+FMT_CONSTEXPR void set_dynamic_spec(
+    T &value, basic_format_arg<Context> arg, ErrorHandler eh) {
+  unsigned long long big_value = visit(Handler<ErrorHandler>(eh), arg);
+  if (big_value > (std::numeric_limits<int>::max)())
+    eh.on_error("number is too big");
+  value = static_cast<int>(big_value);
+}
+
+struct auto_id {};
+
+// The standard format specifier handler with checking.
+template <typename Context>
+class specs_handler: public specs_setter<typename Context::char_type> {
+ public:
+  typedef typename Context::char_type char_type;
+
+  FMT_CONSTEXPR specs_handler(basic_format_specs<char_type> &specs, Context &ctx)
+    : specs_setter<char_type>(specs), context_(ctx) {}
+
+  template <typename Id>
+  FMT_CONSTEXPR void on_dynamic_width(Id arg_id) {
+    set_dynamic_spec<width_checker>(
+          this->specs_.width_, get_arg(arg_id), context_.error_handler());
+  }
+
+  template <typename Id>
+  FMT_CONSTEXPR void on_dynamic_precision(Id arg_id) {
+    set_dynamic_spec<precision_checker>(
+          this->specs_.precision_, get_arg(arg_id), context_.error_handler());
+  }
+
+  void on_error(const char *message) {
+    context_.on_error(message);
+  }
+
+ private:
+  FMT_CONSTEXPR basic_format_arg<Context> get_arg(auto_id) {
+    return context_.next_arg();
+  }
+
+  template <typename Id>
+  FMT_CONSTEXPR basic_format_arg<Context> get_arg(Id arg_id) {
+    context_.parse_context().check_arg_id(arg_id);
+    return context_.get_arg(arg_id);
+  }
+
+  Context &context_;
+};
+
+// An argument reference.
+template <typename Char>
+struct arg_ref {
+  enum Kind { NONE, INDEX, NAME };
+
+  FMT_CONSTEXPR arg_ref() : kind(NONE), index(0) {}
+  FMT_CONSTEXPR explicit arg_ref(unsigned index) : kind(INDEX), index(index) {}
+  explicit arg_ref(basic_string_view<Char> name) : kind(NAME), name(name) {}
+
+  FMT_CONSTEXPR arg_ref &operator=(unsigned idx) {
+    kind = INDEX;
+    index = idx;
+    return *this;
+  }
+
+  Kind kind;
+  FMT_UNION {
+    unsigned index;
+    basic_string_view<Char> name;
+  };
+};
+
+// Format specifiers with width and precision resolved at formatting rather
+// than parsing time to allow re-using the same parsed specifiers with
+// differents sets of arguments (precompilation of format strings).
+template <typename Char>
+struct dynamic_format_specs : basic_format_specs<Char> {
+  arg_ref<Char> width_ref;
+  arg_ref<Char> precision_ref;
+};
+
+// Format spec handler that saves references to arguments representing dynamic
+// width and precision to be resolved at formatting time.
+template <typename ParseContext>
+class dynamic_specs_handler :
+    public specs_setter<typename ParseContext::char_type> {
+ public:
+  typedef typename ParseContext::char_type char_type;
+
+  FMT_CONSTEXPR dynamic_specs_handler(
+      dynamic_format_specs<char_type> &specs, ParseContext &ctx)
+    : specs_setter<char_type>(specs), specs_(specs), context_(ctx) {}
+
+  FMT_CONSTEXPR dynamic_specs_handler(const dynamic_specs_handler &other)
+    : specs_setter<char_type>(other),
+      specs_(other.specs_), context_(other.context_) {}
+
+  template <typename Id>
+  FMT_CONSTEXPR void on_dynamic_width(Id arg_id) {
+    specs_.width_ref = make_arg_ref(arg_id);
+  }
+
+  template <typename Id>
+  FMT_CONSTEXPR void on_dynamic_precision(Id arg_id) {
+    specs_.precision_ref = make_arg_ref(arg_id);
+  }
+
+  FMT_CONSTEXPR void on_error(const char *message) {
+    context_.on_error(message);
+  }
+
+ private:
+  typedef arg_ref<char_type> arg_ref_type;
+
+  template <typename Id>
+  FMT_CONSTEXPR arg_ref_type make_arg_ref(Id arg_id) {
+    context_.check_arg_id(arg_id);
+    return arg_ref_type(arg_id);
+  }
+
+  FMT_CONSTEXPR arg_ref_type make_arg_ref(auto_id) {
+    return arg_ref_type(context_.next_arg_id());
+  }
+
+  dynamic_format_specs<char_type> &specs_;
+  ParseContext &context_;
+};
+
+template <typename Iterator, typename IDHandler>
+FMT_CONSTEXPR Iterator parse_arg_id(Iterator it, IDHandler &&handler) {
+  typedef typename std::iterator_traits<Iterator>::value_type char_type;
+  char_type c = *it;
+  if (c == '}' || c == ':') {
+    handler();
+    return it;
+  }
+  if (c >= '0' && c <= '9') {
+    unsigned index = parse_nonnegative_int(it, handler);
+    if (*it != '}' && *it != ':') {
+      handler.on_error("invalid format string");
+      return it;
+    }
+    handler(index);
+    return it;
+  }
+  if (!is_name_start(c)) {
+    handler.on_error("invalid format string");
+    return it;
+  }
+  auto start = it;
+  do {
+    c = *++it;
+  } while (is_name_start(c) || ('0' <= c && c <= '9'));
+  handler(basic_string_view<char_type>(pointer_from(start), it - start));
+  return it;
+}
+
+// Adapts SpecHandler to IDHandler API for dynamic width.
+template <typename SpecHandler, typename Char>
+struct width_adapter {
+  explicit FMT_CONSTEXPR width_adapter(SpecHandler &h) : handler(h) {}
+
+  FMT_CONSTEXPR void operator()() { handler.on_dynamic_width(auto_id()); }
+  FMT_CONSTEXPR void operator()(unsigned id) { handler.on_dynamic_width(id); }
+  FMT_CONSTEXPR void operator()(basic_string_view<Char> id) {
+    handler.on_dynamic_width(id);
+  }
+
+  FMT_CONSTEXPR void on_error(const char *message) {
+    handler.on_error(message);
+  }
+
+  SpecHandler &handler;
+};
+
+// Adapts SpecHandler to IDHandler API for dynamic precision.
+template <typename SpecHandler, typename Char>
+struct precision_adapter {
+  explicit FMT_CONSTEXPR precision_adapter(SpecHandler &h) : handler(h) {}
+
+  FMT_CONSTEXPR void operator()() { handler.on_dynamic_precision(auto_id()); }
+  FMT_CONSTEXPR void operator()(unsigned id) {
+    handler.on_dynamic_precision(id);
+  }
+  FMT_CONSTEXPR void operator()(basic_string_view<Char> id) {
+    handler.on_dynamic_precision(id);
+  }
+
+  FMT_CONSTEXPR void on_error(const char *message) { handler.on_error(message); }
+
+  SpecHandler &handler;
+};
+
+// Parses standard format specifiers and sends notifications about parsed
+// components to handler.
+// it: an iterator pointing to the beginning of a null-terminated range of
+//     characters, possibly emulated via null_terminating_iterator, representing
+//     format specifiers.
+template <typename Iterator, typename SpecHandler>
+FMT_CONSTEXPR Iterator parse_format_specs(Iterator it, SpecHandler &&handler) {
+  typedef typename std::iterator_traits<Iterator>::value_type char_type;
+  // Parse fill and alignment.
+  if (char_type c = *it) {
+    alignment align = ALIGN_DEFAULT;
+    int i = 1;
+    do {
+      auto p = it + i;
+      switch (*p) {
+        case '<':
+          align = ALIGN_LEFT;
+          break;
+        case '>':
+          align = ALIGN_RIGHT;
+          break;
+        case '=':
+          align = ALIGN_NUMERIC;
+          break;
+        case '^':
+          align = ALIGN_CENTER;
+          break;
+      }
+      if (align != ALIGN_DEFAULT) {
+        handler.on_align(align);
+        if (p != it) {
+          if (c == '}') break;
+          if (c == '{') {
+            handler.on_error("invalid fill character '{'");
+            return it;
+          }
+          it += 2;
+          handler.on_fill(c);
+        } else ++it;
+        break;
+      }
+    } while (--i >= 0);
+  }
+
+  // Parse sign.
+  switch (*it) {
+    case '+':
+      handler.on_plus();
+      ++it;
+      break;
+    case '-':
+      handler.on_minus();
+      ++it;
+      break;
+    case ' ':
+      handler.on_space();
+      ++it;
+      break;
+  }
+
+  if (*it == '#') {
+    handler.on_hash();
+    ++it;
+  }
+
+  // Parse zero flag.
+  if (*it == '0') {
+    handler.on_zero();
+    ++it;
+  }
+
+  // Parse width.
+  if ('0' <= *it && *it <= '9') {
+    handler.on_width(parse_nonnegative_int(it, handler));
+  } else if (*it == '{') {
+    it = parse_arg_id(it + 1, width_adapter<SpecHandler, char_type>(handler));
+    if (*it++ != '}') {
+      handler.on_error("invalid format string");
+      return it;
+    }
+  }
+
+  // Parse precision.
+  if (*it == '.') {
+    ++it;
+    if ('0' <= *it && *it <= '9') {
+      handler.on_precision(parse_nonnegative_int(it, handler));
+    } else if (*it == '{') {
+      it = parse_arg_id(
+            it + 1, precision_adapter<SpecHandler, char_type>(handler));
+      if (*it++ != '}') {
+        handler.on_error("invalid format string");
+        return it;
+      }
+    } else {
+      handler.on_error("missing precision specifier");
+      return it;
+    }
+    handler.end_precision();
+  }
+
+  // Parse type.
+  if (*it != '}' && *it)
+    handler.on_type(*it++);
+  return it;
+}
+
+template <typename Handler, typename Char>
+struct id_adapter {
+  FMT_CONSTEXPR explicit id_adapter(Handler &h): handler(h) {}
+
+  FMT_CONSTEXPR void operator()() { handler.on_arg_id(); }
+  FMT_CONSTEXPR void operator()(unsigned id) { handler.on_arg_id(id); }
+  FMT_CONSTEXPR void operator()(basic_string_view<Char> id) {
+    handler.on_arg_id(id);
+  }
+
+  FMT_CONSTEXPR void on_error(const char *message) {
+    handler.on_error(message);
+  }
+
+  Handler &handler;
+};
+
+template <typename Iterator, typename Handler>
+FMT_CONSTEXPR void parse_format_string(Iterator it, Handler &&handler) {
+  typedef typename std::iterator_traits<Iterator>::value_type char_type;
+  auto start = it;
+  while (*it) {
+    char_type ch = *it++;
+    if (ch != '{' && ch != '}') continue;
+    if (*it == ch) {
+      handler.on_text(start, it);
+      start = ++it;
+      continue;
+    }
+    if (ch == '}') {
+      handler.on_error("unmatched '}' in format string");
+      return;
+    }
+    handler.on_text(start, it - 1);
+
+    it = parse_arg_id(it, id_adapter<Handler, char_type>(handler));
+    if (*it == '}') {
+      handler.on_replacement_field(it);
+    } else if (*it == ':') {
+      ++it;
+      it = handler.on_format_specs(it);
+      if (*it != '}') {
+        handler.on_error("unknown format specifier");
+        return;
+      }
+    } else {
+      handler.on_error("missing '}' in format string");
+      return;
+    }
+
+    start = ++it;
+  }
+  handler.on_text(start, it);
+}
+
+template <typename T, typename ParseContext>
+FMT_CONSTEXPR const typename ParseContext::char_type *
+    parse_format_specs(ParseContext &ctx) {
+  // GCC 7.2 requires initializer.
+  formatter<T, typename ParseContext::char_type> f{};
+  return f.parse(ctx);
+}
+
+template <typename Char, typename ErrorHandler, typename... Args>
+class format_string_checker {
+ public:
+  explicit FMT_CONSTEXPR format_string_checker(
+      basic_string_view<Char> format_str, ErrorHandler eh)
+    : arg_id_(-1), context_(format_str, eh),
+      parse_funcs_{&parse_format_specs<Args, parse_context_type>...} {}
+
+  FMT_CONSTEXPR void on_text(const Char *, const Char *) {}
+
+  FMT_CONSTEXPR void on_arg_id() {
+    arg_id_ = context_.next_arg_id();
+    check_arg_id();
+  }
+  FMT_CONSTEXPR void on_arg_id(unsigned id) {
+    arg_id_ = id;
+    context_.check_arg_id(id);
+    check_arg_id();
+  }
+  FMT_CONSTEXPR void on_arg_id(basic_string_view<Char>) {}
+
+  FMT_CONSTEXPR void on_replacement_field(const Char *) {}
+
+  FMT_CONSTEXPR const Char *on_format_specs(const Char *s) {
+    context_.advance_to(s);
+    return to_unsigned(arg_id_) < NUM_ARGS ?
+          parse_funcs_[arg_id_](context_) : s;
+  }
+
+  FMT_CONSTEXPR void on_error(const char *message) {
+    context_.on_error(message);
+  }
+
+ private:
+  typedef basic_parse_context<Char, ErrorHandler> parse_context_type;
+  enum { NUM_ARGS = sizeof...(Args) };
+
+  FMT_CONSTEXPR void check_arg_id() {
+    if (internal::to_unsigned(arg_id_) >= NUM_ARGS)
+      context_.on_error("argument index out of range");
+  }
+
+  // Format specifier parsing function.
+  typedef const Char *(*parse_func)(parse_context_type &);
+
+  int arg_id_;
+  parse_context_type context_;
+  parse_func parse_funcs_[NUM_ARGS > 0 ? NUM_ARGS : 1];
+};
+
+template <typename Char, typename ErrorHandler, typename... Args>
+FMT_CONSTEXPR bool check_format_string(
+    basic_string_view<Char> s, ErrorHandler eh = ErrorHandler()) {
+  format_string_checker<Char, ErrorHandler, Args...> checker(s, eh);
+  parse_format_string(s.begin(), checker);
+  return true;
+}
+
+template <typename... Args, typename String>
+void check_format_string(String format_str) {
+  FMT_CONSTEXPR_DECL bool invalid_format =
+      internal::check_format_string<char, internal::error_handler, Args...>(
+        string_view(format_str.data(), format_str.size()));
+  (void)invalid_format;
+}
+
+// Specifies whether to format T using the standard formatter.
+// It is not possible to use get_type in formatter specialization directly
+// because of a bug in MSVC.
+template <typename Context, typename T>
+struct format_type :
+  std::integral_constant<bool, get_type<Context, T>::value != custom_type> {};
+
+// Specifies whether to format enums.
+template <typename T, typename Enable = void>
+struct format_enum : std::integral_constant<bool, std::is_enum<T>::value> {};
+
+template <template <typename> class Handler, typename Spec, typename Context>
+void handle_dynamic_spec(
+    Spec &value, arg_ref<typename Context::char_type> ref, Context &ctx) {
+  typedef typename Context::char_type char_type;
+  switch (ref.kind) {
+  case arg_ref<char_type>::NONE:
+    break;
+  case arg_ref<char_type>::INDEX:
+    internal::set_dynamic_spec<Handler>(
+          value, ctx.get_arg(ref.index), ctx.error_handler());
+    break;
+  case arg_ref<char_type>::NAME:
+    internal::set_dynamic_spec<Handler>(
+          value, ctx.get_arg(ref.name), ctx.error_handler());
+    break;
+  }
+}
+}  // namespace internal
+
+/** The default argument formatter. */
+template <typename Range>
+class arg_formatter:
+  public internal::function<void>, public internal::arg_formatter_base<Range> {
+ private:
+  typedef typename Range::value_type char_type;
+  typedef internal::arg_formatter_base<Range> base;
+  typedef basic_format_context<typename base::iterator, char_type> context_type;
+
+  context_type &ctx_;
+
+ public:
+  typedef Range range;
+  typedef typename base::iterator iterator;
+  typedef typename base::format_specs format_specs;
+
+  /**
+    \rst
+    Constructs an argument formatter object.
+    *ctx* is a reference to the formatting context,
+    *spec* contains format specifier information for standard argument types.
+    \endrst
+   */
+  arg_formatter(context_type &ctx, format_specs &spec)
+  : base(Range(ctx.out()), spec), ctx_(ctx) {}
+
+  using base::operator();
+
+  /** Formats an argument of a user-defined type. */
+  iterator operator()(typename basic_format_arg<context_type>::handle handle) {
+    handle.format(ctx_);
+    return this->out();
+  }
+};
+
+/**
+ An error returned by an operating system or a language runtime,
+ for example a file opening error.
+*/
+class system_error : public std::runtime_error {
+ private:
+  FMT_API void init(int err_code, string_view format_str, format_args args);
+
+ protected:
+  int error_code_;
+
+  system_error() : std::runtime_error("") {}
+
+ public:
+  /**
+   \rst
+   Constructs a :class:`fmt::system_error` object with a description
+   formatted with `fmt::format_system_error`. *message* and additional
+   arguments passed into the constructor are formatted similarly to
+   `fmt::format`.
+
+   **Example**::
+
+     // This throws a system_error with the description
+     //   cannot open file 'madeup': No such file or directory
+     // or similar (system message may vary).
+     const char *filename = "madeup";
+     std::FILE *file = std::fopen(filename, "r");
+     if (!file)
+       throw fmt::system_error(errno, "cannot open file '{}'", filename);
+   \endrst
+  */
+  template <typename... Args>
+  system_error(int error_code, string_view message, const Args & ... args)
+    : std::runtime_error("") {
+    init(error_code, message, make_format_args(args...));
+  }
+
+  FMT_API ~system_error() FMT_DTOR_NOEXCEPT;
+
+  int error_code() const { return error_code_; }
+};
+
+/**
+  \rst
+  Formats an error returned by an operating system or a language runtime,
+  for example a file opening error, and writes it to *out* in the following
+  form:
+
+  .. parsed-literal::
+     *<message>*: *<system-message>*
+
+  where *<message>* is the passed message and *<system-message>* is
+  the system message corresponding to the error code.
+  *error_code* is a system error code as given by ``errno``.
+  If *error_code* is not a valid error code such as -1, the system message
+  may look like "Unknown error -1" and is platform-dependent.
+  \endrst
+ */
+FMT_API void format_system_error(fmt::internal::buffer &out, int error_code,
+                                 fmt::string_view message) FMT_NOEXCEPT;
+
+/**
+  This template provides operations for formatting and writing data into a
+  character range.
+ */
+template <typename Range>
+class basic_writer {
+ public:
+  typedef typename Range::value_type char_type;
+  typedef decltype(internal::declval<Range>().begin()) iterator;
+  typedef basic_format_specs<char_type> format_specs;
+
+ private:
+  // Output iterator.
+  iterator out_;
+
+  std::unique_ptr<locale_provider> locale_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(basic_writer);
+
+  iterator out() const { return out_; }
+
+  // Attempts to reserve space for n extra characters in the output range.
+  // Returns a pointer to the reserved range or a reference to out_.
+  auto reserve(std::size_t n) -> decltype(internal::reserve(out_, n)) {
+    return internal::reserve(out_, n);
+  }
+
+  // Writes a value in the format
+  //   <left-padding><value><right-padding>
+  // where <value> is written by f(it).
+  template <typename F>
+  void write_padded(std::size_t size, const align_spec &spec, F f);
+
+  template <typename F>
+  struct padded_int_writer {
+    string_view prefix;
+    char_type fill;
+    std::size_t padding;
+    F f;
+
+    template <typename It>
+    void operator()(It &&it) const {
+      if (prefix.size() != 0)
+        it = std::copy_n(prefix.data(), prefix.size(), it);
+      it = std::fill_n(it, padding, fill);
+      f(it);
+    }
+  };
+
+  // Writes an integer in the format
+  //   <left-padding><prefix><numeric-padding><digits><right-padding>
+  // where <digits> are written by f(it).
+  template <typename Spec, typename F>
+  void write_int(unsigned num_digits, string_view prefix,
+                 const Spec &spec, F f) {
+    std::size_t size = prefix.size() + num_digits;
+    char_type fill = static_cast<char_type>(spec.fill());
+    std::size_t padding = 0;
+    if (spec.align() == ALIGN_NUMERIC) {
+      if (spec.width() > size) {
+        padding = spec.width() - size;
+        size = spec.width();
+      }
+    } else if (spec.precision() > static_cast<int>(num_digits)) {
+      size = prefix.size() + spec.precision();
+      padding = spec.precision() - num_digits;
+      fill = '0';
+    }
+    align_spec as = spec;
+    if (spec.align() == ALIGN_DEFAULT)
+      as.align_ = ALIGN_RIGHT;
+    write_padded(size, as, padded_int_writer<F>{prefix, fill, padding, f});
+  }
+
+  // Writes a decimal integer.
+  template <typename Int>
+  void write_decimal(Int value) {
+    typedef typename internal::int_traits<Int>::main_type main_type;
+    main_type abs_value = static_cast<main_type>(value);
+    bool is_negative = internal::is_negative(value);
+    if (is_negative)
+      abs_value = 0 - abs_value;
+    unsigned num_digits = internal::count_digits(abs_value);
+    auto &&it = reserve((is_negative ? 1 : 0) + num_digits);
+    if (is_negative)
+      *it++ = '-';
+    internal::format_decimal(it, abs_value, num_digits);
+  }
+
+  // The handle_int_type_spec handler that writes an integer.
+  template <typename Int, typename Spec>
+  struct int_writer {
+    typedef typename internal::int_traits<Int>::main_type unsigned_type;
+
+    basic_writer<Range> &writer;
+    const Spec &spec;
+    unsigned_type abs_value;
+    char prefix[4];
+    unsigned prefix_size;
+
+    string_view get_prefix() const { return string_view(prefix, prefix_size); }
+
+    // Counts the number of digits in abs_value. BITS = log2(radix).
+    template <unsigned BITS>
+    unsigned count_digits() const {
+      unsigned_type n = abs_value;
+      unsigned num_digits = 0;
+      do {
+        ++num_digits;
+      } while ((n >>= BITS) != 0);
+      return num_digits;
+    }
+
+    int_writer(basic_writer<Range> &w, Int value, const Spec &s)
+      : writer(w), spec(s), abs_value(static_cast<unsigned_type>(value)),
+        prefix_size(0) {
+      if (internal::is_negative(value)) {
+        prefix[0] = '-';
+        ++prefix_size;
+        abs_value = 0 - abs_value;
+      } else if (spec.flag(SIGN_FLAG)) {
+        prefix[0] = spec.flag(PLUS_FLAG) ? '+' : ' ';
+        ++prefix_size;
+      }
+    }
+
+    struct dec_writer {
+      unsigned_type abs_value;
+      unsigned num_digits;
+
+      template <typename It>
+      void operator()(It &&it) const {
+        it = internal::format_decimal(it, abs_value, num_digits);
+      }
+    };
+
+    void on_dec() {
+      unsigned num_digits = internal::count_digits(abs_value);
+      writer.write_int(num_digits, get_prefix(), spec,
+                       dec_writer{abs_value, num_digits});
+    }
+
+    struct hex_writer {
+      int_writer &self;
+      unsigned num_digits;
+
+      template <typename It>
+      void operator()(It &&it) const {
+        it = internal::format_uint<4>(it, self.abs_value, num_digits,
+                                      self.spec.type() != 'x');
+      }
+    };
+
+    void on_hex() {
+      if (spec.flag(HASH_FLAG)) {
+        prefix[prefix_size++] = '0';
+        prefix[prefix_size++] = static_cast<char>(spec.type());
+      }
+      unsigned num_digits = count_digits<4>();
+      writer.write_int(num_digits, get_prefix(), spec,
+                       hex_writer{*this, num_digits});
+    }
+
+    template <int BITS>
+    struct bin_writer {
+      unsigned_type abs_value;
+      unsigned num_digits;
+
+      template <typename It>
+      void operator()(It &&it) const {
+        it = internal::format_uint<BITS>(it, abs_value, num_digits);
+      }
+    };
+
+    void on_bin() {
+      if (spec.flag(HASH_FLAG)) {
+        prefix[prefix_size++] = '0';
+        prefix[prefix_size++] = static_cast<char>(spec.type());
+      }
+      unsigned num_digits = count_digits<1>();
+      writer.write_int(num_digits, get_prefix(), spec,
+                       bin_writer<1>{abs_value, num_digits});
+    }
+
+    void on_oct() {
+      unsigned num_digits = count_digits<3>();
+      if (spec.flag(HASH_FLAG) &&
+          spec.precision() <= static_cast<int>(num_digits)) {
+        // Octal prefix '0' is counted as a digit, so only add it if precision
+        // is not greater than the number of digits.
+        prefix[prefix_size++] = '0';
+      }
+      writer.write_int(num_digits, get_prefix(), spec,
+                       bin_writer<3>{abs_value, num_digits});
+    }
+
+    enum { SEP_SIZE = 1 };
+
+    struct num_writer {
+      unsigned_type abs_value;
+      unsigned size;
+      char_type sep;
+
+      template <typename It>
+      void operator()(It &&it) const {
+        basic_string_view<char_type> s(&sep, SEP_SIZE);
+        it = format_decimal(it, abs_value, size,
+                            internal::add_thousands_sep<char_type>(s));
+      }
+    };
+
+    void on_num() {
+      unsigned num_digits = internal::count_digits(abs_value);
+      char_type sep = internal::thousands_sep<char_type>(writer.locale_.get());
+      unsigned size = num_digits + SEP_SIZE * ((num_digits - 1) / 3);
+      writer.write_int(size, get_prefix(), spec,
+                       num_writer{abs_value, size, sep});
+    }
+
+    void on_error() {
+      FMT_THROW(format_error("invalid type specifier"));
+    }
+  };
+
+  // Writes a formatted integer.
+  template <typename T, typename Spec>
+  void write_int(T value, const Spec &spec) {
+    internal::handle_int_type_spec(spec.type(),
+                                   int_writer<T, Spec>(*this, value, spec));
+  }
+
+  enum {INF_SIZE = 3}; // This is an enum to workaround a bug in MSVC.
+
+  struct inf_or_nan_writer {
+    char sign;
+    const char *str;
+
+    template <typename It>
+    void operator()(It &&it) const {
+      if (sign)
+        *it++ = sign;
+      it = std::copy_n(str, static_cast<std::size_t>(INF_SIZE), it);
+    }
+  };
+
+  struct double_writer {
+    unsigned n;
+    char sign;
+    basic_memory_buffer<char_type> &buffer;
+
+    template <typename It>
+    void operator()(It &&it) {
+      if (sign) {
+        *it++ = sign;
+        --n;
+      }
+      it = std::copy_n(buffer.begin(), n, it);
+    }
+  };
+
+  // Formats a floating-point number (double or long double).
+  template <typename T>
+  void write_double(T value, const format_specs &spec);
+
+  template <typename Char>
+  struct str_writer {
+    const Char *s;
+    std::size_t size;
+
+    template <typename It>
+    void operator()(It &&it) const {
+      it = std::copy_n(s, size, it);
+    }
+  };
+
+  // Writes a formatted string.
+  template <typename Char>
+  void write_str(const Char *s, std::size_t size, const align_spec &spec) {
+    write_padded(size, spec, str_writer<Char>{s, size});
+  }
+
+  template <typename Char>
+  void write_str(basic_string_view<Char> str, const format_specs &spec);
+
+  // Appends floating-point length specifier to the format string.
+  // The second argument is only used for overload resolution.
+  void append_float_length(char_type *&format_ptr, long double) {
+    *format_ptr++ = 'L';
+  }
+
+  template<typename T>
+  void append_float_length(char_type *&, T) {}
+
+  template <typename Char>
+  friend class internal::arg_formatter_base;
+
+ public:
+  /** Constructs a ``basic_writer`` object. */
+  explicit basic_writer(Range out): out_(out.begin()) {}
+
+  void write(int value) { write_decimal(value); }
+  void write(long value) { write_decimal(value); }
+  void write(long long value) { write_decimal(value); }
+
+  void write(unsigned value) { write_decimal(value); }
+  void write(unsigned long value) { write_decimal(value); }
+  void write(unsigned long long value) { write_decimal(value); }
+
+  /**
+    \rst
+    Formats *value* and writes it to the buffer.
+    \endrst
+   */
+  template <typename T, typename FormatSpec, typename... FormatSpecs>
+  typename std::enable_if<std::is_integral<T>::value, void>::type
+      write(T value, FormatSpec spec, FormatSpecs... specs) {
+    format_specs s(spec, specs...);
+    s.align_ = ALIGN_RIGHT;
+    write_int(value, s);
+  }
+
+  void write(double value) {
+    write_double(value, format_specs());
+  }
+
+  /**
+    \rst
+    Formats *value* using the general format for floating-point numbers
+    (``'g'``) and writes it to the buffer.
+    \endrst
+   */
+  void write(long double value) {
+    write_double(value, format_specs());
+  }
+
+  /** Writes a character to the buffer. */
+  void write(char value) {
+    *reserve(1) = value;
+  }
+
+  void write(wchar_t value) {
+    internal::require_wchar<char_type>();
+    *reserve(1) = value;
+  }
+
+  /**
+    \rst
+    Writes *value* to the buffer.
+    \endrst
+   */
+  void write(string_view value) {
+    auto &&it = reserve(value.size());
+    it = std::copy(value.begin(), value.end(), it);
+  }
+
+  void write(wstring_view value) {
+    internal::require_wchar<char_type>();
+    auto &&it = reserve(value.size());
+    it = std::uninitialized_copy(value.begin(), value.end(), it);
+  }
+
+  template <typename... FormatSpecs>
+  void write(basic_string_view<char_type> str, FormatSpecs... specs) {
+    write_str(str, format_specs(specs...));
+  }
+
+  template <typename T>
+  typename std::enable_if<std::is_same<T, void>::value>::type write(const T* p) {
+    format_specs specs;
+    specs.flags_ = HASH_FLAG;
+    specs.type_ = 'x';
+    write_int(reinterpret_cast<uintptr_t>(p), specs);
+  }
+};
+
+template <typename Range>
+template <typename F>
+void basic_writer<Range>::write_padded(
+    std::size_t size, const align_spec &spec, F f) {
+  unsigned width = spec.width();
+  if (width <= size)
+    return f(reserve(size));
+  auto &&it = reserve(width);
+  char_type fill = static_cast<char_type>(spec.fill());
+  std::size_t padding = width - size;
+  if (spec.align() == ALIGN_RIGHT) {
+    it = std::fill_n(it, padding, fill);
+    f(it);
+  } else if (spec.align() == ALIGN_CENTER) {
+    std::size_t left_padding = padding / 2;
+    it = std::fill_n(it, left_padding, fill);
+    f(it);
+    it = std::fill_n(it, padding - left_padding, fill);
+  } else {
+    f(it);
+    it = std::fill_n(it, padding, fill);
+  }
+}
+
+template <typename Range>
+template <typename Char>
+void basic_writer<Range>::write_str(
+    basic_string_view<Char> s, const format_specs &spec) {
+  const Char *data = s.data();
+  std::size_t size = s.size();
+  std::size_t precision = static_cast<std::size_t>(spec.precision_);
+  if (spec.precision_ >= 0 && precision < size)
+    size = precision;
+  write_str(data, size, spec);
+}
+
+template <typename Char>
+struct float_spec_handler {
+  Char type;
+  bool upper;
+
+  explicit float_spec_handler(Char t) : type(t), upper(false) {}
+
+  void on_general() {
+    if (type == 'G')
+      upper = true;
+    else
+      type = 'g';
+  }
+
+  void on_exp() {
+    if (type == 'E')
+      upper = true;
+  }
+
+  void on_fixed() {
+    if (type == 'F') {
+      upper = true;
+#if FMT_MSC_VER
+      // MSVC's printf doesn't support 'F'.
+      type = 'f';
+#endif
+    }
+  }
+
+  void on_hex() {
+    if (type == 'A')
+      upper = true;
+  }
+
+  void on_error() {
+    FMT_THROW(format_error("invalid type specifier"));
+  }
+};
+
+template <typename Range>
+template <typename T>
+void basic_writer<Range>::write_double(T value, const format_specs &spec) {
+  // Check type.
+  float_spec_handler<char_type> handler(spec.type());
+  internal::handle_float_type_spec(spec.type(), handler);
+
+  char sign = 0;
+  // Use isnegative instead of value < 0 because the latter is always
+  // false for NaN.
+  if (internal::fputil::isnegative(static_cast<double>(value))) {
+    sign = '-';
+    value = -value;
+  } else if (spec.flag(SIGN_FLAG)) {
+    sign = spec.flag(PLUS_FLAG) ? '+' : ' ';
+  }
+
+  struct write_inf_or_nan_t {
+    basic_writer &writer;
+    format_specs spec;
+    char sign;
+    void operator()(const char *str) const {
+      writer.write_padded(INF_SIZE + (sign ? 1 : 0), spec,
+                          inf_or_nan_writer{sign, str});
+    }
+  } write_inf_or_nan = {*this, spec, sign};
+
+  // Format NaN and ininity ourselves because sprintf's output is not consistent
+  // across platforms.
+  if (internal::fputil::isnotanumber(value))
+    return write_inf_or_nan(handler.upper ? "NAN" : "nan");
+  if (internal::fputil::isinfinity(value))
+    return write_inf_or_nan(handler.upper ? "INF" : "inf");
+
+  basic_memory_buffer<char_type> buffer;
+
+  unsigned width = spec.width();
+  if (sign) {
+    buffer.reserve(width > 1u ? width : 1u);
+    if (width > 0)
+      --width;
+  }
+
+  // Build format string.
+  enum { MAX_FORMAT_SIZE = 10}; // longest format: %#-*.*Lg
+  char_type format[MAX_FORMAT_SIZE];
+  char_type *format_ptr = format;
+  *format_ptr++ = '%';
+  unsigned width_for_sprintf = width;
+  if (spec.flag(HASH_FLAG))
+    *format_ptr++ = '#';
+  width_for_sprintf = 0;
+  if (spec.precision() >= 0) {
+    *format_ptr++ = '.';
+    *format_ptr++ = '*';
+  }
+
+  append_float_length(format_ptr, value);
+  *format_ptr++ = handler.type;
+  *format_ptr = '\0';
+
+  // Format using snprintf.
+  unsigned n = 0;
+  char_type *start = FMT_NULL;
+  for (;;) {
+    std::size_t buffer_size = buffer.capacity();
+#if FMT_MSC_VER
+    // MSVC's vsnprintf_s doesn't work with zero size, so reserve
+    // space for at least one extra character to make the size non-zero.
+    // Note that the buffer's capacity may increase by more than 1.
+    if (buffer_size == 0) {
+      buffer.reserve(1);
+      buffer_size = buffer.capacity();
+    }
+#endif
+    start = &buffer[0];
+    int result = internal::char_traits<char_type>::format_float(
+        start, buffer_size, format, width_for_sprintf, spec.precision(), value);
+    if (result >= 0) {
+      n = internal::to_unsigned(result);
+      if (n < buffer.capacity())
+        break;  // The buffer is large enough - continue with formatting.
+      buffer.reserve(n + 1);
+    } else {
+      // If result is negative we ask to increase the capacity by at least 1,
+      // but as std::vector, the buffer grows exponentially.
+      buffer.reserve(buffer.capacity() + 1);
+    }
+  }
+  align_spec as = spec;
+  if (spec.align() == ALIGN_NUMERIC) {
+    if (sign) {
+      *reserve(1) = sign;
+      sign = 0;
+      if (as.width_)
+        --as.width_;
+    }
+    as.align_ = ALIGN_RIGHT;
+  } else {
+    if (spec.align() == ALIGN_DEFAULT)
+      as.align_ = ALIGN_RIGHT;
+    if (sign)
+      ++n;
+  }
+  write_padded(n, as, double_writer{n, sign, buffer});
+}
+
+template <typename OutputIt, typename T = typename OutputIt::value_type>
+class output_range {
+ private:
+  OutputIt it_;
+
+  // Unused yet.
+  typedef void sentinel;
+  sentinel end() const;
+
+ public:
+  typedef OutputIt iterator;
+  typedef T value_type;
+
+  explicit output_range(OutputIt it): it_(it) {}
+  OutputIt begin() const { return it_; }
+};
+
+// A range where begin() returns back_insert_iterator.
+template <typename Container>
+class back_insert_range:
+    public output_range<std::back_insert_iterator<Container>> {
+  typedef output_range<std::back_insert_iterator<Container>> base;
+ public:
+  typedef typename Container::value_type value_type;
+
+  back_insert_range(Container &c): base(std::back_inserter(c)) {}
+  back_insert_range(typename base::iterator it): base(it) {}
+};
+
+typedef basic_writer<back_insert_range<internal::buffer>> writer;
+typedef basic_writer<back_insert_range<internal::wbuffer>> wwriter;
+
+// Reports a system error without throwing an exception.
+// Can be used to report errors from destructors.
+FMT_API void report_system_error(int error_code,
+                                 string_view message) FMT_NOEXCEPT;
+
+#if FMT_USE_WINDOWS_H
+
+/** A Windows error. */
+class windows_error : public system_error {
+ private:
+  FMT_API void init(int error_code, string_view format_str, format_args args);
+
+ public:
+  /**
+   \rst
+   Constructs a :class:`fmt::windows_error` object with the description
+   of the form
+
+   .. parsed-literal::
+     *<message>*: *<system-message>*
+
+   where *<message>* is the formatted message and *<system-message>* is the
+   system message corresponding to the error code.
+   *error_code* is a Windows error code as given by ``GetLastError``.
+   If *error_code* is not a valid error code such as -1, the system message
+   will look like "error -1".
+
+   **Example**::
+
+     // This throws a windows_error with the description
+     //   cannot open file 'madeup': The system cannot find the file specified.
+     // or similar (system message may vary).
+     const char *filename = "madeup";
+     LPOFSTRUCT of = LPOFSTRUCT();
+     HFILE file = OpenFile(filename, &of, OF_READ);
+     if (file == HFILE_ERROR) {
+       throw fmt::windows_error(GetLastError(),
+                                "cannot open file '{}'", filename);
+     }
+   \endrst
+  */
+  template <typename... Args>
+  windows_error(int error_code, string_view message, const Args & ... args) {
+    init(error_code, message, make_format_args(args...));
+  }
+};
+
+// Reports a Windows error without throwing an exception.
+// Can be used to report errors from destructors.
+FMT_API void report_windows_error(int error_code,
+                                  string_view message) FMT_NOEXCEPT;
+
+#endif
+
+/** Fast integer formatter. */
+class FormatInt {
+ private:
+  // Buffer should be large enough to hold all digits (digits10 + 1),
+  // a sign and a null character.
+  enum {BUFFER_SIZE = std::numeric_limits<unsigned long long>::digits10 + 3};
+  mutable char buffer_[BUFFER_SIZE];
+  char *str_;
+
+  // Formats value in reverse and returns a pointer to the beginning.
+  char *format_decimal(unsigned long long value) {
+    char *ptr = buffer_ + BUFFER_SIZE - 1;
+    while (value >= 100) {
+      // Integer division is slow so do it for a group of two digits instead
+      // of for every digit. The idea comes from the talk by Alexandrescu
+      // "Three Optimization Tips for C++". See speed-test for a comparison.
+      unsigned index = static_cast<unsigned>((value % 100) * 2);
+      value /= 100;
+      *--ptr = internal::data::DIGITS[index + 1];
+      *--ptr = internal::data::DIGITS[index];
+    }
+    if (value < 10) {
+      *--ptr = static_cast<char>('0' + value);
+      return ptr;
+    }
+    unsigned index = static_cast<unsigned>(value * 2);
+    *--ptr = internal::data::DIGITS[index + 1];
+    *--ptr = internal::data::DIGITS[index];
+    return ptr;
+  }
+
+  void format_signed(long long value) {
+    unsigned long long abs_value = static_cast<unsigned long long>(value);
+    bool negative = value < 0;
+    if (negative)
+      abs_value = 0 - abs_value;
+    str_ = format_decimal(abs_value);
+    if (negative)
+      *--str_ = '-';
+  }
+
+ public:
+  explicit FormatInt(int value) { format_signed(value); }
+  explicit FormatInt(long value) { format_signed(value); }
+  explicit FormatInt(long long value) { format_signed(value); }
+  explicit FormatInt(unsigned value) : str_(format_decimal(value)) {}
+  explicit FormatInt(unsigned long value) : str_(format_decimal(value)) {}
+  explicit FormatInt(unsigned long long value) : str_(format_decimal(value)) {}
+
+  /** Returns the number of characters written to the output buffer. */
+  std::size_t size() const {
+    return internal::to_unsigned(buffer_ - str_ + BUFFER_SIZE - 1);
+  }
+
+  /**
+    Returns a pointer to the output buffer content. No terminating null
+    character is appended.
+   */
+  const char *data() const { return str_; }
+
+  /**
+    Returns a pointer to the output buffer content with terminating null
+    character appended.
+   */
+  const char *c_str() const {
+    buffer_[BUFFER_SIZE - 1] = '\0';
+    return str_;
+  }
+
+  /**
+    \rst
+    Returns the content of the output buffer as an ``std::string``.
+    \endrst
+   */
+  std::string str() const { return std::string(str_, size()); }
+};
+
+// Formats a decimal integer value writing into buffer and returns
+// a pointer to the end of the formatted string. This function doesn't
+// write a terminating null character.
+template <typename T>
+inline void format_decimal(char *&buffer, T value) {
+  typedef typename internal::int_traits<T>::main_type main_type;
+  main_type abs_value = static_cast<main_type>(value);
+  if (internal::is_negative(value)) {
+    *buffer++ = '-';
+    abs_value = 0 - abs_value;
+  }
+  if (abs_value < 100) {
+    if (abs_value < 10) {
+      *buffer++ = static_cast<char>('0' + abs_value);
+      return;
+    }
+    unsigned index = static_cast<unsigned>(abs_value * 2);
+    *buffer++ = internal::data::DIGITS[index];
+    *buffer++ = internal::data::DIGITS[index + 1];
+    return;
+  }
+  unsigned num_digits = internal::count_digits(abs_value);
+  internal::format_decimal(buffer, abs_value, num_digits);
+  buffer += num_digits;
+}
+
+// Formatter of objects of type T.
+template <typename T, typename Char>
+struct formatter<
+    T, Char,
+    typename std::enable_if<internal::format_type<
+        typename buffer_context<Char>::type, T>::value>::type> {
+
+  // Parses format specifiers stopping either at the end of the range or at the
+  // terminating '}'.
+  template <typename ParseContext>
+  FMT_CONSTEXPR typename ParseContext::iterator parse(ParseContext &ctx) {
+    auto it = internal::null_terminating_iterator<Char>(ctx);
+    typedef internal::dynamic_specs_handler<ParseContext> handler_type;
+    auto type = internal::get_type<
+      typename buffer_context<Char>::type, T>::value;
+    internal::specs_checker<handler_type>
+        handler(handler_type(specs_, ctx), type);
+    it = parse_format_specs(it, handler);
+    auto type_spec = specs_.type();
+    auto eh = ctx.error_handler();
+    switch (type) {
+    case internal::none_type:
+    case internal::name_arg_type:
+      FMT_ASSERT(false, "invalid argument type");
+      break;
+    case internal::int_type:
+    case internal::uint_type:
+    case internal::long_long_type:
+    case internal::ulong_long_type:
+    case internal::bool_type:
+      handle_int_type_spec(
+            type_spec, internal::int_type_checker<decltype(eh)>(eh));
+      break;
+    case internal::char_type:
+      handle_char_specs(specs_, internal::char_specs_checker<decltype(eh)>(
+                          type_spec, eh));
+      break;
+    case internal::double_type:
+    case internal::long_double_type:
+      handle_float_type_spec(
+            type_spec, internal::float_type_checker<decltype(eh)>(eh));
+      break;
+    case internal::cstring_type:
+      internal::handle_cstring_type_spec(
+            type_spec, internal::cstring_type_checker<decltype(eh)>(eh));
+      break;
+    case internal::string_type:
+      internal::check_string_type_spec(type_spec, eh);
+      break;
+    case internal::pointer_type:
+      internal::check_pointer_type_spec(type_spec, eh);
+      break;
+    case internal::custom_type:
+      // Custom format specifiers should be checked in parse functions of
+      // formatter specializations.
+      break;
+    }
+    return pointer_from(it);
+  }
+
+  template <typename FormatContext>
+  auto format(const T &val, FormatContext &ctx) -> decltype(ctx.out()) {
+    internal::handle_dynamic_spec<internal::width_checker>(
+      specs_.width_, specs_.width_ref, ctx);
+    internal::handle_dynamic_spec<internal::precision_checker>(
+      specs_.precision_, specs_.precision_ref, ctx);
+    typedef output_range<typename FormatContext::iterator,
+                         typename FormatContext::char_type> range;
+    visit(arg_formatter<range>(ctx, specs_),
+          internal::make_arg<FormatContext>(val));
+    return ctx.out();
+  }
+
+ private:
+  internal::dynamic_format_specs<Char> specs_;
+};
+
+template <typename T, typename Char>
+struct formatter<T, Char,
+    typename std::enable_if<internal::format_enum<T>::value>::type>
+    : public formatter<int, Char> {
+  template <typename ParseContext>
+  auto parse(ParseContext &ctx) -> decltype(ctx.begin()) {
+    return ctx.begin();
+  }
+};
+
+// A formatter for types known only at run time such as variant alternatives.
+//
+// Usage:
+//   typedef std::variant<int, std::string> variant;
+//   template <>
+//   struct formatter<variant>: dynamic_formatter<> {
+//     void format(buffer &buf, const variant &v, context &ctx) {
+//       visit([&](const auto &val) { format(buf, val, ctx); }, v);
+//     }
+//   };
+template <typename Char = char>
+class dynamic_formatter {
+ private:
+  struct null_handler: internal::error_handler {
+    void on_align(alignment) {}
+    void on_plus() {}
+    void on_minus() {}
+    void on_space() {}
+    void on_hash() {}
+  };
+
+ public:
+  template <typename ParseContext>
+  auto parse(ParseContext &ctx) -> decltype(ctx.begin()) {
+    auto it = internal::null_terminating_iterator<Char>(ctx);
+    // Checks are deferred to formatting time when the argument type is known.
+    internal::dynamic_specs_handler<ParseContext> handler(specs_, ctx);
+    it = parse_format_specs(it, handler);
+    return pointer_from(it);
+  }
+
+  template <typename T, typename FormatContext>
+  auto format(const T &val, FormatContext &ctx) -> decltype(ctx.out()) {
+    handle_specs(ctx);
+    internal::specs_checker<null_handler>
+        checker(null_handler(), internal::get_type<FormatContext, T>::value);
+    checker.on_align(specs_.align());
+    if (specs_.flags_ == 0) {
+      // Do nothing.
+    } else if (specs_.flag(SIGN_FLAG)) {
+      if (specs_.flag(PLUS_FLAG))
+        checker.on_plus();
+      else
+        checker.on_space();
+    } else if (specs_.flag(MINUS_FLAG)) {
+      checker.on_minus();
+    } else if (specs_.flag(HASH_FLAG)) {
+      checker.on_hash();
+    }
+    if (specs_.precision_ != -1)
+      checker.end_precision();
+    typedef output_range<typename FormatContext::iterator,
+                         typename FormatContext::char_type> range;
+    visit(arg_formatter<range>(ctx, specs_),
+          internal::make_arg<FormatContext>(val));
+    return ctx.out();
+  }
+
+ private:
+  template <typename Context>
+  void handle_specs(Context &ctx) {
+    internal::handle_dynamic_spec<internal::width_checker>(
+      specs_.width_, specs_.width_ref, ctx);
+    internal::handle_dynamic_spec<internal::precision_checker>(
+      specs_.precision_, specs_.precision_ref, ctx);
+  }
+
+  internal::dynamic_format_specs<Char> specs_;
+};
+
+template <typename Range, typename Char>
+typename basic_format_context<Range, Char>::format_arg
+  basic_format_context<Range, Char>::get_arg(basic_string_view<char_type> name) {
+  map_.init(this->args());
+  format_arg arg = map_.find(name);
+  if (arg.type() == internal::none_type)
+    this->on_error("argument not found");
+  return arg;
+}
+
+template <typename ArgFormatter, typename Char, typename Context>
+struct format_handler : internal::error_handler {
+  typedef internal::null_terminating_iterator<Char> iterator;
+  typedef typename ArgFormatter::range range;
+
+  format_handler(range r, basic_string_view<Char> str,
+                 basic_format_args<Context> format_args)
+    : context(r.begin(), str, format_args) {}
+
+  void on_text(iterator begin, iterator end) {
+    size_t size = end - begin;
+    auto out = context.out();
+    auto &&it = internal::reserve(out, size);
+    it = std::copy_n(begin, size, it);
+    context.advance_to(out);
+  }
+
+  void on_arg_id() { arg = context.next_arg(); }
+  void on_arg_id(unsigned id) {
+    context.parse_context().check_arg_id(id);
+    arg = context.get_arg(id);
+  }
+  void on_arg_id(basic_string_view<Char> id) {
+    arg = context.get_arg(id);
+  }
+
+  void on_replacement_field(iterator it) {
+    context.parse_context().advance_to(pointer_from(it));
+    if (visit(internal::custom_formatter<Char, Context>(context), arg))
+      return;
+    basic_format_specs<Char> specs;
+    context.advance_to(visit(ArgFormatter(context, specs), arg));
+  }
+
+  iterator on_format_specs(iterator it) {
+    auto& parse_ctx = context.parse_context();
+    parse_ctx.advance_to(pointer_from(it));
+    if (visit(internal::custom_formatter<Char, Context>(context), arg))
+      return iterator(parse_ctx);
+    basic_format_specs<Char> specs;
+    using internal::specs_handler;
+    internal::specs_checker<specs_handler<Context>>
+        handler(specs_handler<Context>(specs, context), arg.type());
+    it = parse_format_specs(it, handler);
+    if (*it != '}')
+      on_error("missing '}' in format string");
+    parse_ctx.advance_to(pointer_from(it));
+    context.advance_to(visit(ArgFormatter(context, specs), arg));
+    return it;
+  }
+
+  Context context;
+  basic_format_arg<Context> arg;
+};
+
+/** Formats arguments and writes the output to the range. */
+template <typename ArgFormatter, typename Char, typename Context>
+typename Context::iterator vformat_to(typename ArgFormatter::range out,
+                                      basic_string_view<Char> format_str,
+                                      basic_format_args<Context> args) {
+  typedef internal::null_terminating_iterator<Char> iterator;
+  format_handler<ArgFormatter, Char, Context> h(out, format_str, args);
+  parse_format_string(iterator(format_str.begin(), format_str.end()), h);
+  return h.context.out();
+}
+
+// Casts ``p`` to ``const void*`` for pointer formatting.
+// Example:
+//   auto s = format("{}", ptr(p));
+template <typename T>
+inline const void *ptr(const T *p) { return p; }
+
+template <typename It, typename Char>
+struct arg_join {
+  It begin;
+  It end;
+  basic_string_view<Char> sep;
+
+  arg_join(It begin, It end, basic_string_view<Char> sep)
+    : begin(begin), end(end), sep(sep) {}
+};
+
+template <typename It, typename Char>
+struct formatter<arg_join<It, Char>, Char>:
+    formatter<typename std::iterator_traits<It>::value_type, Char> {
+  template <typename FormatContext>
+  auto format(const arg_join<It, Char> &value, FormatContext &ctx)
+      -> decltype(ctx.out()) {
+    typedef formatter<typename std::iterator_traits<It>::value_type, Char> base;
+    auto it = value.begin;
+    auto out = ctx.out();
+    if (it != value.end) {
+      out = base::format(*it++, ctx);
+      while (it != value.end) {
+        out = std::copy(value.sep.begin(), value.sep.end(), out);
+        ctx.advance_to(out);
+        out = base::format(*it++, ctx);
+      }
+    }
+    return out;
+  }
+};
+
+template <typename It>
+arg_join<It, char> join(It begin, It end, string_view sep) {
+  return arg_join<It, char>(begin, end, sep);
+}
+
+template <typename It>
+arg_join<It, wchar_t> join(It begin, It end, wstring_view sep) {
+  return arg_join<It, wchar_t>(begin, end, sep);
+}
+
+// The following causes ICE in gcc 4.4.
+#if FMT_USE_TRAILING_RETURN && (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 405)
+template <typename Range>
+auto join(const Range &range, string_view sep)
+    -> arg_join<decltype(internal::begin(range)), char> {
+  return join(internal::begin(range), internal::end(range), sep);
+}
+
+template <typename Range>
+auto join(const Range &range, wstring_view sep)
+    -> arg_join<decltype(internal::begin(range)), wchar_t> {
+  return join(internal::begin(range), internal::end(range), sep);
+}
+#endif
+
+/**
+  \rst
+  Converts *value* to ``std::string`` using the default format for type *T*.
+
+  **Example**::
+
+    #include <fmt/format.h>
+
+    std::string answer = fmt::to_string(42);
+  \endrst
+ */
+template <typename T>
+std::string to_string(const T &value) {
+  std::string str;
+  internal::container_buffer<std::string> buf(str);
+  writer(buf).write(value);
+  return str;
+}
+
+template <typename T>
+std::wstring to_wstring(const T &value) {
+  std::wstring str;
+  internal::container_buffer<std::wstring> buf(str);
+  wwriter(buf).write(value);
+  return str;
+}
+
+template <typename Char>
+std::basic_string<Char> to_string(const basic_memory_buffer<Char> &buffer) {
+  return std::basic_string<Char>(buffer.data(), buffer.size());
+}
+
+inline format_context::iterator vformat_to(
+    internal::buffer &buf, string_view format_str, format_args args) {
+  typedef back_insert_range<internal::buffer> range;
+  return vformat_to<arg_formatter<range>>(buf, format_str, args);
+}
+
+inline wformat_context::iterator vformat_to(
+    internal::wbuffer &buf, wstring_view format_str, wformat_args args) {
+  typedef back_insert_range<internal::wbuffer> range;
+  return vformat_to<arg_formatter<range>>(buf, format_str, args);
+}
+
+template <typename... Args>
+inline format_context::iterator format_to(
+    memory_buffer &buf, string_view format_str, const Args & ... args) {
+  return vformat_to(buf, format_str, make_format_args(args...));
+}
+
+template <typename... Args>
+inline wformat_context::iterator format_to(
+    wmemory_buffer &buf, wstring_view format_str, const Args & ... args) {
+  return vformat_to(buf, format_str, make_format_args<wformat_context>(args...));
+}
+
+template <typename OutputIt, typename Char = char>
+//using format_context_t = basic_format_context<OutputIt, Char>;
+struct format_context_t { typedef basic_format_context<OutputIt, Char> type; };
+
+template <typename OutputIt, typename Char = char>
+//using format_args_t = basic_format_args<format_context_t<OutputIt, Char>>;
+struct format_args_t {
+  typedef basic_format_args<
+    typename format_context_t<OutputIt, Char>::type> type;
+};
+
+template <typename OutputIt, typename... Args>
+inline OutputIt vformat_to(OutputIt out, string_view format_str,
+                           typename format_args_t<OutputIt>::type args) {
+  typedef output_range<OutputIt, char> range;
+  return vformat_to<arg_formatter<range>>(range(out), format_str, args);
+}
+
+template <typename OutputIt, typename... Args>
+inline OutputIt format_to(OutputIt out, string_view format_str,
+                          const Args & ... args) {
+  return vformat_to(out, format_str,
+      make_format_args<typename format_context_t<OutputIt>::type>(args...));
+}
+
+template <typename Container, typename... Args>
+inline typename std::enable_if<
+  is_contiguous<Container>::value, std::back_insert_iterator<Container>>::type
+    format_to(std::back_insert_iterator<Container> out,
+              string_view format_str, const Args & ... args) {
+  return vformat_to(out, format_str, make_format_args<format_context>(args...));
+}
+
+template <typename Container, typename... Args>
+inline typename std::enable_if<
+  is_contiguous<Container>::value, std::back_insert_iterator<Container>>::type
+    format_to(std::back_insert_iterator<Container> out,
+              wstring_view format_str, const Args & ... args) {
+  return vformat_to(out, format_str, make_format_args<wformat_context>(args...));
+}
+
+template <typename OutputIt>
+struct format_to_n_result {
+  /** Iterator past the end of the output range. */
+  OutputIt out;
+  /** Total (not truncated) output size. */
+  std::size_t size;
+};
+
+/**
+ \rst
+ Formats arguments, writes up to ``n`` characters of the result to the output
+ iterator ``out`` and returns the total output size and the iterator past the end
+ of the output range.
+ \endrst
+ */
+template <typename OutputIt, typename... Args>
+inline format_to_n_result<OutputIt> format_to_n(
+    OutputIt out, std::size_t n, string_view format_str, const Args & ... args) {
+  typedef internal::truncating_iterator<OutputIt> It;
+  auto it = vformat_to(It(out, n), format_str,
+      make_format_args<typename format_context_t<It>::type>(args...));
+  return {it.base(), it.count()};
+}
+
+inline std::string vformat(string_view format_str, format_args args) {
+  memory_buffer buffer;
+  vformat_to(buffer, format_str, args);
+  return fmt::to_string(buffer);
+}
+
+inline std::wstring vformat(wstring_view format_str, wformat_args args) {
+  wmemory_buffer buffer;
+  vformat_to(buffer, format_str, args);
+  return to_string(buffer);
+}
+
+template <typename String, typename... Args>
+inline typename std::enable_if<
+  internal::is_format_string<String>::value, std::string>::type
+    format(String format_str, const Args & ... args) {
+  internal::check_format_string<Args...>(format_str);
+  return vformat(format_str.data(), make_format_args(args...));
+}
+
+template <typename String, typename... Args>
+inline typename std::enable_if<internal::is_format_string<String>::value>::type
+    print(String format_str, const Args & ... args) {
+  internal::check_format_string<Args...>(format_str);
+  return vprint(format_str.data(), make_format_args(args...));
+}
+
+// Counts the number of characters in the output of format(format_str, args...).
+template <typename... Args>
+inline std::size_t formatted_size(string_view format_str,
+                                  const Args & ... args) {
+  auto it = format_to(internal::counting_iterator<char>(), format_str, args...);
+  return it.count();
+}
+}  // namespace fmt
+
+#if FMT_USE_USER_DEFINED_LITERALS
+namespace fmt {
+namespace internal {
+
+# if FMT_UDL_TEMPLATE
+template <typename Char, Char... CHARS>
+class udl_formatter {
+ public:
+  template <typename... Args>
+  std::basic_string<Char> operator()(const Args &... args) const {
+    FMT_CONSTEXPR_DECL Char s[] = {CHARS..., '\0'};
+    FMT_CONSTEXPR_DECL bool invalid_format =
+        check_format_string<Char, error_handler, Args...>(
+          basic_string_view<Char>(s, sizeof...(CHARS)));
+    (void)invalid_format;
+    return format(s, args...);
+  }
+};
+# else
+template <typename Char>
+struct udl_formatter {
+  const Char *str;
+
+  template <typename... Args>
+  auto operator()(Args && ... args) const
+                  -> decltype(format(str, std::forward<Args>(args)...)) {
+    return format(str, std::forward<Args>(args)...);
+  }
+};
+# endif // FMT_UDL_TEMPLATE
+
+template <typename Char>
+struct udl_arg {
+  const Char *str;
+
+  template <typename T>
+  named_arg<T, Char> operator=(T &&value) const {
+    return {str, std::forward<T>(value)};
+  }
+};
+
+} // namespace internal
+
+inline namespace literals {
+
+# if FMT_UDL_TEMPLATE
+template <typename Char, Char... CHARS>
+FMT_CONSTEXPR internal::udl_formatter<Char, CHARS...> operator""_format() {
+  return {};
+}
+# else
+/**
+  \rst
+  User-defined literal equivalent of :func:`fmt::format`.
+
+  **Example**::
+
+    using namespace fmt::literals;
+    std::string message = "The answer is {}"_format(42);
+  \endrst
+ */
+inline internal::udl_formatter<char>
+operator"" _format(const char *s, std::size_t) { return {s}; }
+inline internal::udl_formatter<wchar_t>
+operator"" _format(const wchar_t *s, std::size_t) { return {s}; }
+# endif // FMT_UDL_TEMPLATE
+
+/**
+  \rst
+  User-defined literal equivalent of :func:`fmt::arg`.
+
+  **Example**::
+
+    using namespace fmt::literals;
+    fmt::print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
+  \endrst
+ */
+inline internal::udl_arg<char>
+operator"" _a(const char *s, std::size_t) { return {s}; }
+inline internal::udl_arg<wchar_t>
+operator"" _a(const wchar_t *s, std::size_t) { return {s}; }
+} // inline namespace literals
+} // namespace fmt
+#endif // FMT_USE_USER_DEFINED_LITERALS
+
+#define FMT_STRING(s) [] { \
+    struct S : fmt::format_string { \
+      static FMT_CONSTEXPR auto data() { return s; } \
+      static FMT_CONSTEXPR size_t size() { return sizeof(s); } \
+    }; \
+    return S{}; \
+  }()
+
+#ifndef FMT_NO_FMT_STRING_ALIAS
+/**
+  \rst
+  Constructs a compile-time format string.
+
+  **Example**::
+
+    #include <fmt/format.h>
+    // A compile-time error because 'd' is an invalid specifier for strings.
+    std::string s = fmt::format(fmt("{:d}"), "foo");
+  \endrst
+ */
+# define fmt(s) FMT_STRING(s)
+#endif
+
+#ifdef FMT_HEADER_ONLY
+# define FMT_FUNC inline
+# include "format-inl.h"
+#else
+# define FMT_FUNC
+#endif
+
+// Restore warnings.
+#if FMT_GCC_VERSION >= 406
+# pragma GCC diagnostic pop
+#endif
+
+#if defined(__clang__) && !defined(FMT_ICC_VERSION)
+# pragma clang diagnostic pop
+#endif
+
+#endif  // FMT_FORMAT_H_

--- a/contrib/fmt/include/fmt/locale.h
+++ b/contrib/fmt/include/fmt/locale.h
@@ -1,0 +1,20 @@
+// Formatting library for C++ - locale support
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#include "format.h"
+#include <locale>
+
+namespace fmt {
+class locale {
+ private:
+  std::locale locale_;
+
+ public:
+  explicit locale(std::locale loc = std::locale()) : locale_(loc) {}
+  std::locale get() { return locale_; }
+};
+}

--- a/contrib/fmt/include/fmt/ostream.h
+++ b/contrib/fmt/include/fmt/ostream.h
@@ -1,0 +1,155 @@
+// Formatting library for C++ - std::ostream support
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_OSTREAM_H_
+#define FMT_OSTREAM_H_
+
+#include "format.h"
+#include <ostream>
+
+namespace fmt {
+
+namespace internal {
+
+template <class Char>
+class FormatBuf : public std::basic_streambuf<Char> {
+ private:
+  typedef typename std::basic_streambuf<Char>::int_type int_type;
+  typedef typename std::basic_streambuf<Char>::traits_type traits_type;
+
+  basic_buffer<Char> &buffer_;
+
+ public:
+  FormatBuf(basic_buffer<Char> &buffer) : buffer_(buffer) {}
+
+ protected:
+  // The put-area is actually always empty. This makes the implementation
+  // simpler and has the advantage that the streambuf and the buffer are always
+  // in sync and sputc never writes into uninitialized memory. The obvious
+  // disadvantage is that each call to sputc always results in a (virtual) call
+  // to overflow. There is no disadvantage here for sputn since this always
+  // results in a call to xsputn.
+
+  int_type overflow(int_type ch = traits_type::eof()) FMT_OVERRIDE {
+    if (!traits_type::eq_int_type(ch, traits_type::eof()))
+      buffer_.push_back(static_cast<Char>(ch));
+    return ch;
+  }
+
+  std::streamsize xsputn(const Char *s, std::streamsize count) FMT_OVERRIDE {
+    buffer_.append(s, s + count);
+    return count;
+  }
+};
+
+template <typename Char>
+struct test_stream : std::basic_ostream<Char> {
+ private:
+  struct null;
+  // Hide all operator<< from std::basic_ostream<Char>.
+  void operator<<(null);
+};
+
+// Disable conversion to int if T has an overloaded operator<< which is a free
+// function (not a member of std::ostream).
+template <typename T, typename Char>
+class convert_to_int<T, Char, true> {
+ private:
+  template <typename U>
+  static decltype(
+    internal::declval<test_stream<Char>&>()
+      << internal::declval<U>(), std::true_type()) test(int);
+
+  template <typename>
+  static std::false_type test(...);
+
+  typedef decltype(test<T>(0)) result;
+
+ public:
+  static const bool value = !result::value;
+};
+
+// Write the content of buf to os.
+template <typename Char>
+void write(std::basic_ostream<Char> &os, basic_buffer<Char> &buf) {
+  const Char *data = buf.data();
+  typedef std::make_unsigned<std::streamsize>::type UnsignedStreamSize;
+  UnsignedStreamSize size = buf.size();
+  UnsignedStreamSize max_size =
+      internal::to_unsigned((std::numeric_limits<std::streamsize>::max)());
+  do {
+    UnsignedStreamSize n = size <= max_size ? size : max_size;
+    os.write(data, static_cast<std::streamsize>(n));
+    data += n;
+    size -= n;
+  } while (size != 0);
+}
+
+template <typename Char, typename T>
+void format_value(basic_buffer<Char> &buffer, const T &value) {
+  internal::FormatBuf<Char> format_buf(buffer);
+  std::basic_ostream<Char> output(&format_buf);
+  output.exceptions(std::ios_base::failbit | std::ios_base::badbit);
+  output << value;
+  buffer.resize(buffer.size());
+}
+
+// Disable builtin formatting of enums and use operator<< instead.
+template <typename T>
+struct format_enum<T,
+    typename std::enable_if<std::is_enum<T>::value>::type> : std::false_type {};
+}  // namespace internal
+
+// Formats an object of type T that has an overloaded ostream operator<<.
+template <typename T, typename Char>
+struct formatter<T, Char,
+    typename std::enable_if<!internal::format_type<
+      typename buffer_context<Char>::type, T>::value>::type>
+    : formatter<basic_string_view<Char>, Char> {
+
+  template <typename Context>
+  auto format(const T &value, Context &ctx) -> decltype(ctx.out()) {
+    basic_memory_buffer<Char> buffer;
+    internal::format_value(buffer, value);
+    basic_string_view<Char> str(buffer.data(), buffer.size());
+    formatter<basic_string_view<Char>, Char>::format(str, ctx);
+    return ctx.out();
+  }
+};
+
+template <typename Char>
+inline void vprint(std::basic_ostream<Char> &os,
+                   basic_string_view<Char> format_str,
+                   basic_format_args<typename buffer_context<Char>::type> args) {
+  basic_memory_buffer<Char> buffer;
+  vformat_to(buffer, format_str, args);
+  internal::write(os, buffer);
+}
+/**
+  \rst
+  Prints formatted data to the stream *os*.
+
+  **Example**::
+
+    fmt::print(cerr, "Don't {}!", "panic");
+  \endrst
+ */
+template <typename... Args>
+inline void print(std::ostream &os, string_view format_str,
+                  const Args & ... args) {
+  vprint(os, format_str, make_format_args<format_context>(args...));
+}
+
+template <typename... Args>
+inline void print(std::wostream &os, wstring_view format_str,
+                  const Args & ... args) {
+  vprint(os, format_str, make_format_args<wformat_context>(args...));
+}
+
+}  // namespace fmt
+
+#endif  // FMT_OSTREAM_H_

--- a/contrib/fmt/include/fmt/posix.h
+++ b/contrib/fmt/include/fmt/posix.h
@@ -1,0 +1,417 @@
+// A C++ interface to POSIX functions.
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_POSIX_H_
+#define FMT_POSIX_H_
+
+#if defined(__MINGW32__) || defined(__CYGWIN__)
+// Workaround MinGW bug https://sourceforge.net/p/mingw/bugs/2024/.
+# undef __STRICT_ANSI__
+#endif
+
+#include <errno.h>
+#include <fcntl.h>   // for O_RDONLY
+#include <locale.h>  // for locale_t
+#include <stdio.h>
+#include <stdlib.h>  // for strtod_l
+
+#include <cstddef>
+
+#if defined __APPLE__ || defined(__FreeBSD__)
+# include <xlocale.h>  // for LC_NUMERIC_MASK on OS X
+#endif
+
+#include "format.h"
+
+#ifndef FMT_POSIX
+# if defined(_WIN32) && !defined(__MINGW32__)
+// Fix warnings about deprecated symbols.
+#  define FMT_POSIX(call) _##call
+# else
+#  define FMT_POSIX(call) call
+# endif
+#endif
+
+// Calls to system functions are wrapped in FMT_SYSTEM for testability.
+#ifdef FMT_SYSTEM
+# define FMT_POSIX_CALL(call) FMT_SYSTEM(call)
+#else
+# define FMT_SYSTEM(call) call
+# ifdef _WIN32
+// Fix warnings about deprecated symbols.
+#  define FMT_POSIX_CALL(call) ::_##call
+# else
+#  define FMT_POSIX_CALL(call) ::call
+# endif
+#endif
+
+// Retries the expression while it evaluates to error_result and errno
+// equals to EINTR.
+#ifndef _WIN32
+# define FMT_RETRY_VAL(result, expression, error_result) \
+  do { \
+    result = (expression); \
+  } while (result == error_result && errno == EINTR)
+#else
+# define FMT_RETRY_VAL(result, expression, error_result) result = (expression)
+#endif
+
+#define FMT_RETRY(result, expression) FMT_RETRY_VAL(result, expression, -1)
+
+namespace fmt {
+
+/**
+  \rst
+  A reference to a null-terminated string. It can be constructed from a C
+  string or ``std::string``.
+
+  You can use one of the following typedefs for common character types:
+
+  +---------------+-----------------------------+
+  | Type          | Definition                  |
+  +===============+=============================+
+  | cstring_view  | basic_cstring_view<char>    |
+  +---------------+-----------------------------+
+  | wcstring_view | basic_cstring_view<wchar_t> |
+  +---------------+-----------------------------+
+
+  This class is most useful as a parameter type to allow passing
+  different types of strings to a function, for example::
+
+    template <typename... Args>
+    std::string format(cstring_view format_str, const Args & ... args);
+
+    format("{}", 42);
+    format(std::string("{}"), 42);
+  \endrst
+ */
+template <typename Char>
+class basic_cstring_view {
+ private:
+  const Char *data_;
+
+ public:
+  /** Constructs a string reference object from a C string. */
+  basic_cstring_view(const Char *s) : data_(s) {}
+
+  /**
+    \rst
+    Constructs a string reference from an ``std::string`` object.
+    \endrst
+   */
+  basic_cstring_view(const std::basic_string<Char> &s) : data_(s.c_str()) {}
+
+  /** Returns the pointer to a C string. */
+  const Char *c_str() const { return data_; }
+};
+
+typedef basic_cstring_view<char> cstring_view;
+typedef basic_cstring_view<wchar_t> wcstring_view;
+
+// An error code.
+class ErrorCode {
+ private:
+  int value_;
+
+ public:
+  explicit ErrorCode(int value = 0) FMT_NOEXCEPT : value_(value) {}
+
+  int get() const FMT_NOEXCEPT { return value_; }
+};
+
+// A buffered file.
+class BufferedFile {
+ private:
+  FILE *file_;
+
+  friend class File;
+
+  explicit BufferedFile(FILE *f) : file_(f) {}
+
+ public:
+  // Constructs a BufferedFile object which doesn't represent any file.
+  BufferedFile() FMT_NOEXCEPT : file_(FMT_NULL) {}
+
+  // Destroys the object closing the file it represents if any.
+  FMT_API ~BufferedFile() FMT_DTOR_NOEXCEPT;
+
+#if !FMT_USE_RVALUE_REFERENCES
+  // Emulate a move constructor and a move assignment operator if rvalue
+  // references are not supported.
+
+ private:
+  // A proxy object to emulate a move constructor.
+  // It is private to make it impossible call operator Proxy directly.
+  struct Proxy {
+    FILE *file;
+  };
+
+public:
+  // A "move constructor" for moving from a temporary.
+  BufferedFile(Proxy p) FMT_NOEXCEPT : file_(p.file) {}
+
+  // A "move constructor" for moving from an lvalue.
+  BufferedFile(BufferedFile &f) FMT_NOEXCEPT : file_(f.file_) {
+    f.file_ = FMT_NULL;
+  }
+
+  // A "move assignment operator" for moving from a temporary.
+  BufferedFile &operator=(Proxy p) {
+    close();
+    file_ = p.file;
+    return *this;
+  }
+
+  // A "move assignment operator" for moving from an lvalue.
+  BufferedFile &operator=(BufferedFile &other) {
+    close();
+    file_ = other.file_;
+    other.file_ = FMT_NULL;
+    return *this;
+  }
+
+  // Returns a proxy object for moving from a temporary:
+  //   BufferedFile file = BufferedFile(...);
+  operator Proxy() FMT_NOEXCEPT {
+    Proxy p = {file_};
+    file_ = FMT_NULL;
+    return p;
+  }
+
+#else
+ private:
+  FMT_DISALLOW_COPY_AND_ASSIGN(BufferedFile);
+
+ public:
+  BufferedFile(BufferedFile &&other) FMT_NOEXCEPT : file_(other.file_) {
+    other.file_ = FMT_NULL;
+  }
+
+  BufferedFile& operator=(BufferedFile &&other) {
+    close();
+    file_ = other.file_;
+    other.file_ = FMT_NULL;
+    return *this;
+  }
+#endif
+
+  // Opens a file.
+  FMT_API BufferedFile(cstring_view filename, cstring_view mode);
+
+  // Closes the file.
+  FMT_API void close();
+
+  // Returns the pointer to a FILE object representing this file.
+  FILE *get() const FMT_NOEXCEPT { return file_; }
+
+  // We place parentheses around fileno to workaround a bug in some versions
+  // of MinGW that define fileno as a macro.
+  FMT_API int (fileno)() const;
+
+  void vprint(string_view format_str, format_args args) {
+    fmt::vprint(file_, format_str, args);
+  }
+
+  template <typename... Args>
+  inline void print(string_view format_str, const Args & ... args) {
+    vprint(format_str, make_format_args(args...));
+  }
+};
+
+// A file. Closed file is represented by a File object with descriptor -1.
+// Methods that are not declared with FMT_NOEXCEPT may throw
+// fmt::system_error in case of failure. Note that some errors such as
+// closing the file multiple times will cause a crash on Windows rather
+// than an exception. You can get standard behavior by overriding the
+// invalid parameter handler with _set_invalid_parameter_handler.
+class File {
+ private:
+  int fd_;  // File descriptor.
+
+  // Constructs a File object with a given descriptor.
+  explicit File(int fd) : fd_(fd) {}
+
+ public:
+  // Possible values for the oflag argument to the constructor.
+  enum {
+    RDONLY = FMT_POSIX(O_RDONLY), // Open for reading only.
+    WRONLY = FMT_POSIX(O_WRONLY), // Open for writing only.
+    RDWR   = FMT_POSIX(O_RDWR)    // Open for reading and writing.
+  };
+
+  // Constructs a File object which doesn't represent any file.
+  File() FMT_NOEXCEPT : fd_(-1) {}
+
+  // Opens a file and constructs a File object representing this file.
+  FMT_API File(cstring_view path, int oflag);
+
+#if !FMT_USE_RVALUE_REFERENCES
+  // Emulate a move constructor and a move assignment operator if rvalue
+  // references are not supported.
+
+ private:
+  // A proxy object to emulate a move constructor.
+  // It is private to make it impossible call operator Proxy directly.
+  struct Proxy {
+    int fd;
+  };
+
+ public:
+  // A "move constructor" for moving from a temporary.
+  File(Proxy p) FMT_NOEXCEPT : fd_(p.fd) {}
+
+  // A "move constructor" for moving from an lvalue.
+  File(File &other) FMT_NOEXCEPT : fd_(other.fd_) {
+    other.fd_ = -1;
+  }
+
+  // A "move assignment operator" for moving from a temporary.
+  File &operator=(Proxy p) {
+    close();
+    fd_ = p.fd;
+    return *this;
+  }
+
+  // A "move assignment operator" for moving from an lvalue.
+  File &operator=(File &other) {
+    close();
+    fd_ = other.fd_;
+    other.fd_ = -1;
+    return *this;
+  }
+
+  // Returns a proxy object for moving from a temporary:
+  //   File file = File(...);
+  operator Proxy() FMT_NOEXCEPT {
+    Proxy p = {fd_};
+    fd_ = -1;
+    return p;
+  }
+
+#else
+ private:
+  FMT_DISALLOW_COPY_AND_ASSIGN(File);
+
+ public:
+  File(File &&other) FMT_NOEXCEPT : fd_(other.fd_) {
+    other.fd_ = -1;
+  }
+
+  File& operator=(File &&other) {
+    close();
+    fd_ = other.fd_;
+    other.fd_ = -1;
+    return *this;
+  }
+#endif
+
+  // Destroys the object closing the file it represents if any.
+  FMT_API ~File() FMT_DTOR_NOEXCEPT;
+
+  // Returns the file descriptor.
+  int descriptor() const FMT_NOEXCEPT { return fd_; }
+
+  // Closes the file.
+  FMT_API void close();
+
+  // Returns the file size. The size has signed type for consistency with
+  // stat::st_size.
+  FMT_API long long size() const;
+
+  // Attempts to read count bytes from the file into the specified buffer.
+  FMT_API std::size_t read(void *buffer, std::size_t count);
+
+  // Attempts to write count bytes from the specified buffer to the file.
+  FMT_API std::size_t write(const void *buffer, std::size_t count);
+
+  // Duplicates a file descriptor with the dup function and returns
+  // the duplicate as a file object.
+  FMT_API static File dup(int fd);
+
+  // Makes fd be the copy of this file descriptor, closing fd first if
+  // necessary.
+  FMT_API void dup2(int fd);
+
+  // Makes fd be the copy of this file descriptor, closing fd first if
+  // necessary.
+  FMT_API void dup2(int fd, ErrorCode &ec) FMT_NOEXCEPT;
+
+  // Creates a pipe setting up read_end and write_end file objects for reading
+  // and writing respectively.
+  FMT_API static void pipe(File &read_end, File &write_end);
+
+  // Creates a BufferedFile object associated with this file and detaches
+  // this File object from the file.
+  FMT_API BufferedFile fdopen(const char *mode);
+};
+
+// Returns the memory page size.
+long getpagesize();
+
+#if (defined(LC_NUMERIC_MASK) || defined(_MSC_VER)) && \
+    !defined(__ANDROID__) && !defined(__CYGWIN__) && !defined(__OpenBSD__)
+# define FMT_LOCALE
+#endif
+
+#ifdef FMT_LOCALE
+// A "C" numeric locale.
+class Locale {
+ private:
+# ifdef _MSC_VER
+  typedef _locale_t locale_t;
+
+  enum { LC_NUMERIC_MASK = LC_NUMERIC };
+
+  static locale_t newlocale(int category_mask, const char *locale, locale_t) {
+    return _create_locale(category_mask, locale);
+  }
+
+  static void freelocale(locale_t locale) {
+    _free_locale(locale);
+  }
+
+  static double strtod_l(const char *nptr, char **endptr, _locale_t locale) {
+    return _strtod_l(nptr, endptr, locale);
+  }
+# endif
+
+  locale_t locale_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(Locale);
+
+ public:
+  typedef locale_t Type;
+
+  Locale() : locale_(newlocale(LC_NUMERIC_MASK, "C", FMT_NULL)) {
+    if (!locale_)
+      FMT_THROW(fmt::system_error(errno, "cannot create locale"));
+  }
+  ~Locale() { freelocale(locale_); }
+
+  Type get() const { return locale_; }
+
+  // Converts string to floating-point number and advances str past the end
+  // of the parsed input.
+  double strtod(const char *&str) const {
+    char *end = FMT_NULL;
+    double result = strtod_l(str, &end, locale_);
+    str = end;
+    return result;
+  }
+};
+#endif  // FMT_LOCALE
+}  // namespace fmt
+
+#if !FMT_USE_RVALUE_REFERENCES
+namespace std {
+// For compatibility with C++98.
+inline fmt::BufferedFile &move(fmt::BufferedFile &f) { return f; }
+inline fmt::File &move(fmt::File &f) { return f; }
+}
+#endif
+
+#endif  // FMT_POSIX_H_

--- a/contrib/fmt/include/fmt/printf.h
+++ b/contrib/fmt/include/fmt/printf.h
@@ -1,0 +1,711 @@
+// Formatting library for C++
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_PRINTF_H_
+#define FMT_PRINTF_H_
+
+#include <algorithm>  // std::fill_n
+#include <limits>     // std::numeric_limits
+
+#include "ostream.h"
+
+namespace fmt {
+namespace internal {
+
+// Checks if a value fits in int - used to avoid warnings about comparing
+// signed and unsigned integers.
+template <bool IsSigned>
+struct int_checker {
+  template <typename T>
+  static bool fits_in_int(T value) {
+    unsigned max = std::numeric_limits<int>::max();
+    return value <= max;
+  }
+  static bool fits_in_int(bool) { return true; }
+};
+
+template <>
+struct int_checker<true> {
+  template <typename T>
+  static bool fits_in_int(T value) {
+    return value >= std::numeric_limits<int>::min() &&
+           value <= std::numeric_limits<int>::max();
+  }
+  static bool fits_in_int(int) { return true; }
+};
+
+class printf_precision_handler: public function<int> {
+ public:
+  template <typename T>
+  typename std::enable_if<std::is_integral<T>::value, int>::type
+      operator()(T value) {
+    if (!int_checker<std::numeric_limits<T>::is_signed>::fits_in_int(value))
+      FMT_THROW(format_error("number is too big"));
+    return static_cast<int>(value);
+  }
+
+  template <typename T>
+  typename std::enable_if<!std::is_integral<T>::value, int>::type
+      operator()(T) {
+    FMT_THROW(format_error("precision is not integer"));
+    return 0;
+  }
+};
+
+// An argument visitor that returns true iff arg is a zero integer.
+class is_zero_int: public function<bool> {
+ public:
+  template <typename T>
+  typename std::enable_if<std::is_integral<T>::value, bool>::type
+      operator()(T value) { return value == 0; }
+
+  template <typename T>
+  typename std::enable_if<!std::is_integral<T>::value, bool>::type
+      operator()(T) { return false; }
+};
+
+template <typename T>
+struct make_unsigned_or_bool : std::make_unsigned<T> {};
+
+template <>
+struct make_unsigned_or_bool<bool> {
+  typedef bool type;
+};
+
+template <typename T, typename Context>
+class arg_converter: public function<void> {
+ private:
+  typedef typename Context::char_type Char;
+
+  basic_format_arg<Context> &arg_;
+  typename Context::char_type type_;
+
+ public:
+  arg_converter(basic_format_arg<Context> &arg, Char type)
+    : arg_(arg), type_(type) {}
+
+  void operator()(bool value) {
+    if (type_ != 's')
+      operator()<bool>(value);
+  }
+
+  template <typename U>
+  typename std::enable_if<std::is_integral<U>::value>::type
+      operator()(U value) {
+    bool is_signed = type_ == 'd' || type_ == 'i';
+    typedef typename std::conditional<
+        std::is_same<T, void>::value, U, T>::type TargetType;
+    if (const_check(sizeof(TargetType) <= sizeof(int))) {
+      // Extra casts are used to silence warnings.
+      if (is_signed) {
+        arg_ = internal::make_arg<Context>(
+          static_cast<int>(static_cast<TargetType>(value)));
+      } else {
+        typedef typename make_unsigned_or_bool<TargetType>::type Unsigned;
+        arg_ = internal::make_arg<Context>(
+          static_cast<unsigned>(static_cast<Unsigned>(value)));
+      }
+    } else {
+      if (is_signed) {
+        // glibc's printf doesn't sign extend arguments of smaller types:
+        //   std::printf("%lld", -42);  // prints "4294967254"
+        // but we don't have to do the same because it's a UB.
+        arg_ = internal::make_arg<Context>(static_cast<long long>(value));
+      } else {
+        arg_ = internal::make_arg<Context>(
+          static_cast<typename make_unsigned_or_bool<U>::type>(value));
+      }
+    }
+  }
+
+  template <typename U>
+  typename std::enable_if<!std::is_integral<U>::value>::type operator()(U) {
+    // No coversion needed for non-integral types.
+  }
+};
+
+// Converts an integer argument to T for printf, if T is an integral type.
+// If T is void, the argument is converted to corresponding signed or unsigned
+// type depending on the type specifier: 'd' and 'i' - signed, other -
+// unsigned).
+template <typename T, typename Context, typename Char>
+void convert_arg(basic_format_arg<Context> &arg, Char type) {
+  visit(arg_converter<T, Context>(arg, type), arg);
+}
+
+// Converts an integer argument to char for printf.
+template <typename Context>
+class char_converter: public function<void> {
+ private:
+  basic_format_arg<Context> &arg_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(char_converter);
+
+ public:
+  explicit char_converter(basic_format_arg<Context> &arg) : arg_(arg) {}
+
+  template <typename T>
+  typename std::enable_if<std::is_integral<T>::value>::type
+      operator()(T value) {
+    typedef typename Context::char_type Char;
+    arg_ = internal::make_arg<Context>(static_cast<Char>(value));
+  }
+
+  template <typename T>
+  typename std::enable_if<!std::is_integral<T>::value>::type operator()(T) {
+    // No coversion needed for non-integral types.
+  }
+};
+
+// Checks if an argument is a valid printf width specifier and sets
+// left alignment if it is negative.
+template <typename Char>
+class printf_width_handler: public function<unsigned> {
+ private:
+  typedef basic_format_specs<Char> format_specs;
+
+  format_specs &spec_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(printf_width_handler);
+
+ public:
+  explicit printf_width_handler(format_specs &spec) : spec_(spec) {}
+
+  template <typename T>
+  typename std::enable_if<std::is_integral<T>::value, unsigned>::type
+      operator()(T value) {
+    typedef typename internal::int_traits<T>::main_type UnsignedType;
+    UnsignedType width = static_cast<UnsignedType>(value);
+    if (internal::is_negative(value)) {
+      spec_.align_ = ALIGN_LEFT;
+      width = 0 - width;
+    }
+    unsigned int_max = std::numeric_limits<int>::max();
+    if (width > int_max)
+      FMT_THROW(format_error("number is too big"));
+    return static_cast<unsigned>(width);
+  }
+
+  template <typename T>
+  typename std::enable_if<!std::is_integral<T>::value, unsigned>::type
+      operator()(T) {
+    FMT_THROW(format_error("width is not integer"));
+    return 0;
+  }
+};
+}  // namespace internal
+
+template <typename Range>
+class printf_arg_formatter;
+
+template <
+    typename OutputIt, typename Char,
+    typename ArgFormatter =
+      printf_arg_formatter<back_insert_range<internal::basic_buffer<Char>>>>
+class basic_printf_context;
+
+/**
+  \rst
+  The ``printf`` argument formatter.
+  \endrst
+ */
+template <typename Range>
+class printf_arg_formatter:
+  public internal::function<void>, public internal::arg_formatter_base<Range> {
+ private:
+  typedef typename Range::value_type char_type;
+  typedef decltype(internal::declval<Range>().begin()) iterator;
+  typedef internal::arg_formatter_base<Range> base;
+  typedef basic_printf_context<iterator, char_type> context_type;
+
+  context_type &context_;
+
+  void write_null_pointer(char) {
+    this->spec().type_ = 0;
+    this->write("(nil)");
+  }
+
+  void write_null_pointer(wchar_t) {
+    this->spec().type_ = 0;
+    this->write(L"(nil)");
+  }
+
+ public:
+  typedef typename base::format_specs format_specs;
+
+  /**
+    \rst
+    Constructs an argument formatter object.
+    *buffer* is a reference to the output buffer and *spec* contains format
+    specifier information for standard argument types.
+    \endrst
+   */
+  printf_arg_formatter(internal::basic_buffer<char_type> &buffer,
+                       format_specs &spec, context_type &ctx)
+    : base(back_insert_range<internal::basic_buffer<char_type>>(buffer), spec),
+      context_(ctx) {}
+
+  using base::operator();
+
+  /** Formats an argument of type ``bool``. */
+  iterator operator()(bool value) {
+    format_specs &fmt_spec = this->spec();
+    if (fmt_spec.type_ != 's')
+      return (*this)(value ? 1 : 0);
+    fmt_spec.type_ = 0;
+    this->write(value);
+    return this->out();
+  }
+
+  /** Formats a character. */
+  iterator operator()(char_type value) {
+    format_specs &fmt_spec = this->spec();
+    if (fmt_spec.type_ && fmt_spec.type_ != 'c')
+      return (*this)(static_cast<int>(value));
+    fmt_spec.flags_ = 0;
+    fmt_spec.align_ = ALIGN_RIGHT;
+    return base::operator()(value);
+  }
+
+  /** Formats a null-terminated C string. */
+  iterator operator()(const char *value) {
+    if (value)
+      base::operator()(value);
+    else if (this->spec().type_ == 'p')
+      write_null_pointer(char_type());
+    else
+      this->write("(null)");
+    return this->out();
+  }
+
+  /** Formats a null-terminated wide C string. */
+  iterator operator()(const wchar_t *value) {
+    if (value)
+      base::operator()(value);
+    else if (this->spec().type_ == 'p')
+      write_null_pointer(char_type());
+    else
+      this->write(L"(null)");
+    return this->out();
+  }
+
+  /** Formats a pointer. */
+  iterator operator()(const void *value) {
+    if (value)
+      return base::operator()(value);
+    this->spec().type_ = 0;
+    write_null_pointer(char_type());
+    return this->out();
+  }
+
+  /** Formats an argument of a custom (user-defined) type. */
+  iterator operator()(typename basic_format_arg<context_type>::handle handle) {
+    handle.format(context_);
+    return this->out();
+  }
+};
+
+template <typename T>
+struct printf_formatter {
+  template <typename ParseContext>
+  auto parse(ParseContext &ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const T &value, FormatContext &ctx) -> decltype(ctx.out()) {
+    internal::format_value(internal::get_container(ctx.out()), value);
+    return ctx.out();
+  }
+};
+
+/** This template formats data and writes the output to a writer. */
+template <typename OutputIt, typename Char, typename ArgFormatter>
+class basic_printf_context :
+  private internal::context_base<
+    OutputIt, basic_printf_context<OutputIt, Char, ArgFormatter>, Char> {
+ public:
+  /** The character type for the output. */
+  typedef Char char_type;
+
+  template <typename T>
+  struct formatter_type { typedef printf_formatter<T> type; };
+
+ private:
+  typedef internal::context_base<OutputIt, basic_printf_context, Char> base;
+  typedef typename base::format_arg format_arg;
+  typedef basic_format_specs<char_type> format_specs;
+  typedef internal::null_terminating_iterator<char_type> iterator;
+
+  void parse_flags(format_specs &spec, iterator &it);
+
+  // Returns the argument with specified index or, if arg_index is equal
+  // to the maximum unsigned value, the next argument.
+  format_arg get_arg(
+      iterator it,
+      unsigned arg_index = (std::numeric_limits<unsigned>::max)());
+
+  // Parses argument index, flags and width and returns the argument index.
+  unsigned parse_header(iterator &it, format_specs &spec);
+
+ public:
+  /**
+   \rst
+   Constructs a ``printf_context`` object. References to the arguments and
+   the writer are stored in the context object so make sure they have
+   appropriate lifetimes.
+   \endrst
+   */
+  basic_printf_context(OutputIt out, basic_string_view<char_type> format_str,
+                       basic_format_args<basic_printf_context> args)
+    : base(out, format_str, args) {}
+
+  using base::parse_context;
+  using base::out;
+  using base::advance_to;
+
+  /** Formats stored arguments and writes the output to the range. */
+  void format();
+};
+
+template <typename OutputIt, typename Char, typename AF>
+void basic_printf_context<OutputIt, Char, AF>::parse_flags(
+    format_specs &spec, iterator &it) {
+  for (;;) {
+    switch (*it++) {
+      case '-':
+        spec.align_ = ALIGN_LEFT;
+        break;
+      case '+':
+        spec.flags_ |= SIGN_FLAG | PLUS_FLAG;
+        break;
+      case '0':
+        spec.fill_ = '0';
+        break;
+      case ' ':
+        spec.flags_ |= SIGN_FLAG;
+        break;
+      case '#':
+        spec.flags_ |= HASH_FLAG;
+        break;
+      default:
+        --it;
+        return;
+    }
+  }
+}
+
+template <typename OutputIt, typename Char, typename AF>
+typename basic_printf_context<OutputIt, Char, AF>::format_arg
+  basic_printf_context<OutputIt, Char, AF>::get_arg(
+    iterator it, unsigned arg_index) {
+  (void)it;
+  if (arg_index == std::numeric_limits<unsigned>::max())
+    return this->do_get_arg(this->parse_context().next_arg_id());
+  return base::get_arg(arg_index - 1);
+}
+
+template <typename OutputIt, typename Char, typename AF>
+unsigned basic_printf_context<OutputIt, Char, AF>::parse_header(
+  iterator &it, format_specs &spec) {
+  unsigned arg_index = std::numeric_limits<unsigned>::max();
+  char_type c = *it;
+  if (c >= '0' && c <= '9') {
+    // Parse an argument index (if followed by '$') or a width possibly
+    // preceded with '0' flag(s).
+    internal::error_handler eh;
+    unsigned value = parse_nonnegative_int(it, eh);
+    if (*it == '$') {  // value is an argument index
+      ++it;
+      arg_index = value;
+    } else {
+      if (c == '0')
+        spec.fill_ = '0';
+      if (value != 0) {
+        // Nonzero value means that we parsed width and don't need to
+        // parse it or flags again, so return now.
+        spec.width_ = value;
+        return arg_index;
+      }
+    }
+  }
+  parse_flags(spec, it);
+  // Parse width.
+  if (*it >= '0' && *it <= '9') {
+    internal::error_handler eh;
+    spec.width_ = parse_nonnegative_int(it, eh);
+  } else if (*it == '*') {
+    ++it;
+    spec.width_ =
+        visit(internal::printf_width_handler<char_type>(spec), get_arg(it));
+  }
+  return arg_index;
+}
+
+template <typename OutputIt, typename Char, typename AF>
+void basic_printf_context<OutputIt, Char, AF>::format() {
+  auto &buffer = internal::get_container(this->out());
+  auto start = iterator(this->parse_context());
+  auto it = start;
+  using internal::pointer_from;
+  while (*it) {
+    char_type c = *it++;
+    if (c != '%') continue;
+    if (*it == c) {
+      buffer.append(pointer_from(start), pointer_from(it));
+      start = ++it;
+      continue;
+    }
+    buffer.append(pointer_from(start), pointer_from(it) - 1);
+
+    format_specs spec;
+    spec.align_ = ALIGN_RIGHT;
+
+    // Parse argument index, flags and width.
+    unsigned arg_index = parse_header(it, spec);
+
+    // Parse precision.
+    if (*it == '.') {
+      ++it;
+      if ('0' <= *it && *it <= '9') {
+        internal::error_handler eh;
+        spec.precision_ = static_cast<int>(parse_nonnegative_int(it, eh));
+      } else if (*it == '*') {
+        ++it;
+        spec.precision_ =
+            visit(internal::printf_precision_handler(), get_arg(it));
+      } else {
+        spec.precision_ = 0;
+      }
+    }
+
+    format_arg arg = get_arg(it, arg_index);
+    if (spec.flag(HASH_FLAG) && visit(internal::is_zero_int(), arg))
+      spec.flags_ &= ~internal::to_unsigned<int>(HASH_FLAG);
+    if (spec.fill_ == '0') {
+      if (arg.is_arithmetic())
+        spec.align_ = ALIGN_NUMERIC;
+      else
+        spec.fill_ = ' ';  // Ignore '0' flag for non-numeric types.
+    }
+
+    // Parse length and convert the argument to the required type.
+    using internal::convert_arg;
+    switch (*it++) {
+    case 'h':
+      if (*it == 'h')
+        convert_arg<signed char>(arg, *++it);
+      else
+        convert_arg<short>(arg, *it);
+      break;
+    case 'l':
+      if (*it == 'l')
+        convert_arg<long long>(arg, *++it);
+      else
+        convert_arg<long>(arg, *it);
+      break;
+    case 'j':
+      convert_arg<intmax_t>(arg, *it);
+      break;
+    case 'z':
+      convert_arg<std::size_t>(arg, *it);
+      break;
+    case 't':
+      convert_arg<std::ptrdiff_t>(arg, *it);
+      break;
+    case 'L':
+      // printf produces garbage when 'L' is omitted for long double, no
+      // need to do the same.
+      break;
+    default:
+      --it;
+      convert_arg<void>(arg, *it);
+    }
+
+    // Parse type.
+    if (!*it)
+      FMT_THROW(format_error("invalid format string"));
+    spec.type_ = static_cast<char>(*it++);
+    if (arg.is_integral()) {
+      // Normalize type.
+      switch (spec.type_) {
+      case 'i': case 'u':
+        spec.type_ = 'd';
+        break;
+      case 'c':
+        // TODO: handle wchar_t better?
+        visit(internal::char_converter<basic_printf_context>(arg), arg);
+        break;
+      }
+    }
+
+    start = it;
+
+    // Format argument.
+    visit(AF(buffer, spec, *this), arg);
+  }
+  buffer.append(pointer_from(start), pointer_from(it));
+}
+
+template <typename Char, typename Context>
+void printf(internal::basic_buffer<Char> &buf, basic_string_view<Char> format,
+            basic_format_args<Context> args) {
+  Context(std::back_inserter(buf), format, args).format();
+}
+
+template <typename Buffer>
+struct printf_context {
+  typedef basic_printf_context<
+    std::back_insert_iterator<Buffer>, typename Buffer::value_type> type;
+};
+
+template <typename ...Args>
+inline format_arg_store<printf_context<internal::buffer>::type, Args...>
+    make_printf_args(const Args & ... args) {
+  return format_arg_store<printf_context<internal::buffer>::type, Args...>(
+      args...);
+}
+typedef basic_format_args<printf_context<internal::buffer>::type> printf_args;
+typedef basic_format_args<printf_context<internal::wbuffer>::type> wprintf_args;
+
+inline std::string vsprintf(string_view format, printf_args args) {
+  memory_buffer buffer;
+  printf(buffer, format, args);
+  return to_string(buffer);
+}
+
+/**
+  \rst
+  Formats arguments and returns the result as a string.
+
+  **Example**::
+
+    std::string message = fmt::sprintf("The answer is %d", 42);
+  \endrst
+*/
+template <typename... Args>
+inline std::string sprintf(string_view format_str, const Args & ... args) {
+  return vsprintf(format_str,
+    make_format_args<typename printf_context<internal::buffer>::type>(args...));
+}
+
+inline std::wstring vsprintf(wstring_view format, wprintf_args args) {
+  wmemory_buffer buffer;
+  printf(buffer, format, args);
+  return to_string(buffer);
+}
+
+template <typename... Args>
+inline std::wstring sprintf(wstring_view format_str, const Args & ... args) {
+  return vsprintf(format_str,
+    make_format_args<typename printf_context<internal::wbuffer>::type>(args...));
+}
+
+template <typename Char>
+inline int vfprintf(std::FILE *f, basic_string_view<Char> format,
+                    basic_format_args<typename printf_context<
+                      internal::basic_buffer<Char>>::type> args) {
+  basic_memory_buffer<Char> buffer;
+  printf(buffer, format, args);
+  std::size_t size = buffer.size();
+  return std::fwrite(
+    buffer.data(), sizeof(Char), size, f) < size ? -1 : static_cast<int>(size);
+}
+
+/**
+  \rst
+  Prints formatted data to the file *f*.
+
+  **Example**::
+
+    fmt::fprintf(stderr, "Don't %s!", "panic");
+  \endrst
+ */
+template <typename... Args>
+inline int fprintf(std::FILE *f, string_view format_str, const Args & ... args) {
+  auto vargs = make_format_args<
+    typename printf_context<internal::buffer>::type>(args...);
+  return vfprintf(f, format_str, vargs);
+}
+
+template <typename... Args>
+inline int fprintf(std::FILE *f, wstring_view format_str,
+                   const Args & ... args) {
+  return vfprintf(f, format_str,
+    make_format_args<typename printf_context<internal::wbuffer>::type>(args...));
+}
+
+inline int vprintf(string_view format, printf_args args) {
+  return vfprintf(stdout, format, args);
+}
+
+inline int vprintf(wstring_view format, wprintf_args args) {
+  return vfprintf(stdout, format, args);
+}
+
+/**
+  \rst
+  Prints formatted data to ``stdout``.
+
+  **Example**::
+
+    fmt::printf("Elapsed time: %.2f seconds", 1.23);
+  \endrst
+ */
+template <typename... Args>
+inline int printf(string_view format_str, const Args & ... args) {
+  return vprintf(format_str,
+    make_format_args<typename printf_context<internal::buffer>::type>(args...));
+}
+
+template <typename... Args>
+inline int printf(wstring_view format_str, const Args & ... args) {
+  return vprintf(format_str,
+    make_format_args<typename printf_context<internal::wbuffer>::type>(args...));
+}
+
+inline int vfprintf(std::ostream &os, string_view format_str,
+                    printf_args args) {
+  memory_buffer buffer;
+  printf(buffer, format_str, args);
+  internal::write(os, buffer);
+  return static_cast<int>(buffer.size());
+}
+
+inline int vfprintf(std::wostream &os, wstring_view format_str,
+                    wprintf_args args) {
+  wmemory_buffer buffer;
+  printf(buffer, format_str, args);
+  internal::write(os, buffer);
+  return static_cast<int>(buffer.size());
+}
+
+/**
+  \rst
+  Prints formatted data to the stream *os*.
+
+  **Example**::
+
+    fmt::fprintf(cerr, "Don't %s!", "panic");
+  \endrst
+ */
+template <typename... Args>
+inline int fprintf(std::ostream &os, string_view format_str,
+                   const Args & ... args) {
+  auto vargs = make_format_args<
+    typename printf_context<internal::buffer>::type>(args...);
+  return vfprintf(os, format_str, vargs);
+}
+
+template <typename... Args>
+inline int fprintf(std::wostream &os, wstring_view format_str,
+                   const Args & ... args) {
+  auto vargs = make_format_args<
+    typename printf_context<internal::buffer>::type>(args...);
+  return vfprintf(os, format_str, vargs);
+}
+}  // namespace fmt
+
+#endif  // FMT_PRINTF_H_

--- a/contrib/fmt/include/fmt/time.h
+++ b/contrib/fmt/include/fmt/time.h
@@ -1,0 +1,151 @@
+// Formatting library for C++ - time formatting
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_TIME_H_
+#define FMT_TIME_H_
+
+#include "format.h"
+#include <ctime>
+
+namespace fmt {
+
+namespace internal{
+inline null<> localtime_r(...) { return null<>(); }
+inline null<> localtime_s(...) { return null<>(); }
+inline null<> gmtime_r(...) { return null<>(); }
+inline null<> gmtime_s(...) { return null<>(); }
+}
+
+// Thread-safe replacement for std::localtime
+inline std::tm localtime(std::time_t time) {
+  struct LocalTime {
+    std::time_t time_;
+    std::tm tm_;
+
+    LocalTime(std::time_t t): time_(t) {}
+
+    bool run() {
+      using namespace fmt::internal;
+      return handle(localtime_r(&time_, &tm_));
+    }
+
+    bool handle(std::tm *tm) { return tm != FMT_NULL; }
+
+    bool handle(internal::null<>) {
+      using namespace fmt::internal;
+      return fallback(localtime_s(&tm_, &time_));
+    }
+
+    bool fallback(int res) { return res == 0; }
+
+    bool fallback(internal::null<>) {
+      using namespace fmt::internal;
+      std::tm *tm = std::localtime(&time_);
+      if (tm) tm_ = *tm;
+      return tm != FMT_NULL;
+    }
+  };
+  LocalTime lt(time);
+  if (lt.run())
+    return lt.tm_;
+  // Too big time values may be unsupported.
+  FMT_THROW(format_error("time_t value out of range"));
+  return std::tm();
+}
+
+// Thread-safe replacement for std::gmtime
+inline std::tm gmtime(std::time_t time) {
+  struct GMTime {
+    std::time_t time_;
+    std::tm tm_;
+
+    GMTime(std::time_t t): time_(t) {}
+
+    bool run() {
+      using namespace fmt::internal;
+      return handle(gmtime_r(&time_, &tm_));
+    }
+
+    bool handle(std::tm *tm) { return tm != FMT_NULL; }
+
+    bool handle(internal::null<>) {
+      using namespace fmt::internal;
+      return fallback(gmtime_s(&tm_, &time_));
+    }
+
+    bool fallback(int res) { return res == 0; }
+
+    bool fallback(internal::null<>) {
+      std::tm *tm = std::gmtime(&time_);
+      if (tm) tm_ = *tm;
+      return tm != FMT_NULL;
+    }
+  };
+  GMTime gt(time);
+  if (gt.run())
+    return gt.tm_;
+  // Too big time values may be unsupported.
+  FMT_THROW(format_error("time_t value out of range"));
+  return std::tm();
+}
+
+namespace internal {
+inline std::size_t strftime(char *str, std::size_t count, const char *format, const std::tm *time) {
+  return std::strftime(str, count, format, time);
+}
+
+inline std::size_t strftime(wchar_t *str, std::size_t count, const wchar_t *format, const std::tm *time) {
+  return std::wcsftime(str, count, format, time);
+}
+}
+
+template <typename Char>
+struct formatter<std::tm, Char> {
+  template <typename ParseContext>
+  auto parse(ParseContext &ctx) -> decltype(ctx.begin()) {
+    auto it = internal::null_terminating_iterator<Char>(ctx);
+    if (*it == ':')
+      ++it;
+    auto end = it;
+    while (*end && *end != '}')
+      ++end;
+    tm_format.reserve(end - it + 1);
+    using internal::pointer_from;
+    tm_format.append(pointer_from(it), pointer_from(end));
+    tm_format.push_back('\0');
+    return pointer_from(end);
+  }
+
+  template <typename FormatContext>
+  auto format(const std::tm &tm, FormatContext &ctx) -> decltype(ctx.out()) {
+    internal::basic_buffer<Char> &buf = internal::get_container(ctx.out());
+    std::size_t start = buf.size();
+    for (;;) {
+      std::size_t size = buf.capacity() - start;
+      std::size_t count = internal::strftime(&buf[start], size, &tm_format[0], &tm);
+      if (count != 0) {
+        buf.resize(start + count);
+        break;
+      }
+      if (size >= tm_format.size() * 256) {
+        // If the buffer is 256 times larger than the format string, assume
+        // that `strftime` gives an empty result. There doesn't seem to be a
+        // better way to distinguish the two cases:
+        // https://github.com/fmtlib/fmt/issues/367
+        break;
+      }
+      const std::size_t MIN_GROWTH = 10;
+      buf.reserve(buf.capacity() + (size > MIN_GROWTH ? size : MIN_GROWTH));
+    }
+    return ctx.out();
+  }
+
+  basic_memory_buffer<Char> tm_format;
+};
+}
+
+#endif  // FMT_TIME_H_

--- a/contrib/fmt/src/format.cc
+++ b/contrib/fmt/src/format.cc
@@ -1,0 +1,47 @@
+// Formatting library for C++
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#include "fmt/format-inl.h"
+
+namespace fmt {
+
+template struct internal::basic_data<void>;
+
+// Explicit instantiations for char.
+
+template FMT_API char internal::thousands_sep(locale_provider *lp);
+
+template void basic_fixed_buffer<char>::grow(std::size_t);
+
+template void internal::arg_map<format_context>::init(
+    const basic_format_args<format_context> &args);
+
+template FMT_API int internal::char_traits<char>::format_float(
+    char *buffer, std::size_t size, const char *format,
+    unsigned width, int precision, double value);
+
+template FMT_API int internal::char_traits<char>::format_float(
+    char *buffer, std::size_t size, const char *format,
+    unsigned width, int precision, long double value);
+
+// Explicit instantiations for wchar_t.
+
+template FMT_API wchar_t internal::thousands_sep(locale_provider *lp);
+
+template void basic_fixed_buffer<wchar_t>::grow(std::size_t);
+
+template void internal::arg_map<wformat_context>::init(
+    const basic_format_args<wformat_context> &args);
+
+template FMT_API int internal::char_traits<wchar_t>::format_float(
+    wchar_t *buffer, std::size_t size, const wchar_t *format,
+    unsigned width, int precision, double value);
+
+template FMT_API int internal::char_traits<wchar_t>::format_float(
+    wchar_t *buffer, std::size_t size, const wchar_t *format,
+    unsigned width, int precision, long double value);
+}  // namespace fmt

--- a/contrib/fmt/src/posix.cc
+++ b/contrib/fmt/src/posix.cc
@@ -1,0 +1,241 @@
+// A C++ interface to POSIX functions.
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+// Disable bogus MSVC warnings.
+#ifndef _CRT_SECURE_NO_WARNINGS
+# define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include "fmt/posix.h"
+
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#ifndef _WIN32
+# include <unistd.h>
+#else
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <windows.h>
+# include <io.h>
+
+# define O_CREAT _O_CREAT
+# define O_TRUNC _O_TRUNC
+
+# ifndef S_IRUSR
+#  define S_IRUSR _S_IREAD
+# endif
+
+# ifndef S_IWUSR
+#  define S_IWUSR _S_IWRITE
+# endif
+
+# ifdef __MINGW32__
+#  define _SH_DENYNO 0x40
+# endif
+
+#endif  // _WIN32
+
+#ifdef fileno
+# undef fileno
+#endif
+
+namespace {
+#ifdef _WIN32
+// Return type of read and write functions.
+typedef int RWResult;
+
+// On Windows the count argument to read and write is unsigned, so convert
+// it from size_t preventing integer overflow.
+inline unsigned convert_rwcount(std::size_t count) {
+  return count <= UINT_MAX ? static_cast<unsigned>(count) : UINT_MAX;
+}
+#else
+// Return type of read and write functions.
+typedef ssize_t RWResult;
+
+inline std::size_t convert_rwcount(std::size_t count) { return count; }
+#endif
+}
+
+fmt::BufferedFile::~BufferedFile() FMT_NOEXCEPT {
+  if (file_ && FMT_SYSTEM(fclose(file_)) != 0)
+    fmt::report_system_error(errno, "cannot close file");
+}
+
+fmt::BufferedFile::BufferedFile(
+    fmt::cstring_view filename, fmt::cstring_view mode) {
+  FMT_RETRY_VAL(file_,
+                FMT_SYSTEM(fopen(filename.c_str(), mode.c_str())), FMT_NULL);
+  if (!file_)
+    FMT_THROW(system_error(errno, "cannot open file {}", filename.c_str()));
+}
+
+void fmt::BufferedFile::close() {
+  if (!file_)
+    return;
+  int result = FMT_SYSTEM(fclose(file_));
+  file_ = FMT_NULL;
+  if (result != 0)
+    FMT_THROW(system_error(errno, "cannot close file"));
+}
+
+// A macro used to prevent expansion of fileno on broken versions of MinGW.
+#define FMT_ARGS
+
+int fmt::BufferedFile::fileno() const {
+  int fd = FMT_POSIX_CALL(fileno FMT_ARGS(file_));
+  if (fd == -1)
+    FMT_THROW(system_error(errno, "cannot get file descriptor"));
+  return fd;
+}
+
+fmt::File::File(fmt::cstring_view path, int oflag) {
+  int mode = S_IRUSR | S_IWUSR;
+#if defined(_WIN32) && !defined(__MINGW32__)
+  fd_ = -1;
+  FMT_POSIX_CALL(sopen_s(&fd_, path.c_str(), oflag, _SH_DENYNO, mode));
+#else
+  FMT_RETRY(fd_, FMT_POSIX_CALL(open(path.c_str(), oflag, mode)));
+#endif
+  if (fd_ == -1)
+    FMT_THROW(system_error(errno, "cannot open file {}", path.c_str()));
+}
+
+fmt::File::~File() FMT_NOEXCEPT {
+  // Don't retry close in case of EINTR!
+  // See http://linux.derkeiler.com/Mailing-Lists/Kernel/2005-09/3000.html
+  if (fd_ != -1 && FMT_POSIX_CALL(close(fd_)) != 0)
+    fmt::report_system_error(errno, "cannot close file");
+}
+
+void fmt::File::close() {
+  if (fd_ == -1)
+    return;
+  // Don't retry close in case of EINTR!
+  // See http://linux.derkeiler.com/Mailing-Lists/Kernel/2005-09/3000.html
+  int result = FMT_POSIX_CALL(close(fd_));
+  fd_ = -1;
+  if (result != 0)
+    FMT_THROW(system_error(errno, "cannot close file"));
+}
+
+long long fmt::File::size() const {
+#ifdef _WIN32
+  // Use GetFileSize instead of GetFileSizeEx for the case when _WIN32_WINNT
+  // is less than 0x0500 as is the case with some default MinGW builds.
+  // Both functions support large file sizes.
+  DWORD size_upper = 0;
+  HANDLE handle = reinterpret_cast<HANDLE>(_get_osfhandle(fd_));
+  DWORD size_lower = FMT_SYSTEM(GetFileSize(handle, &size_upper));
+  if (size_lower == INVALID_FILE_SIZE) {
+    DWORD error = GetLastError();
+    if (error != NO_ERROR)
+      FMT_THROW(windows_error(GetLastError(), "cannot get file size"));
+  }
+  unsigned long long long_size = size_upper;
+  return (long_size << sizeof(DWORD) * CHAR_BIT) | size_lower;
+#else
+  typedef struct stat Stat;
+  Stat file_stat = Stat();
+  if (FMT_POSIX_CALL(fstat(fd_, &file_stat)) == -1)
+    FMT_THROW(system_error(errno, "cannot get file attributes"));
+  static_assert(sizeof(long long) >= sizeof(file_stat.st_size),
+      "return type of File::size is not large enough");
+  return file_stat.st_size;
+#endif
+}
+
+std::size_t fmt::File::read(void *buffer, std::size_t count) {
+  RWResult result = 0;
+  FMT_RETRY(result, FMT_POSIX_CALL(read(fd_, buffer, convert_rwcount(count))));
+  if (result < 0)
+    FMT_THROW(system_error(errno, "cannot read from file"));
+  return internal::to_unsigned(result);
+}
+
+std::size_t fmt::File::write(const void *buffer, std::size_t count) {
+  RWResult result = 0;
+  FMT_RETRY(result, FMT_POSIX_CALL(write(fd_, buffer, convert_rwcount(count))));
+  if (result < 0)
+    FMT_THROW(system_error(errno, "cannot write to file"));
+  return internal::to_unsigned(result);
+}
+
+fmt::File fmt::File::dup(int fd) {
+  // Don't retry as dup doesn't return EINTR.
+  // http://pubs.opengroup.org/onlinepubs/009695399/functions/dup.html
+  int new_fd = FMT_POSIX_CALL(dup(fd));
+  if (new_fd == -1)
+    FMT_THROW(system_error(errno, "cannot duplicate file descriptor {}", fd));
+  return File(new_fd);
+}
+
+void fmt::File::dup2(int fd) {
+  int result = 0;
+  FMT_RETRY(result, FMT_POSIX_CALL(dup2(fd_, fd)));
+  if (result == -1) {
+    FMT_THROW(system_error(errno,
+      "cannot duplicate file descriptor {} to {}", fd_, fd));
+  }
+}
+
+void fmt::File::dup2(int fd, ErrorCode &ec) FMT_NOEXCEPT {
+  int result = 0;
+  FMT_RETRY(result, FMT_POSIX_CALL(dup2(fd_, fd)));
+  if (result == -1)
+    ec = ErrorCode(errno);
+}
+
+void fmt::File::pipe(File &read_end, File &write_end) {
+  // Close the descriptors first to make sure that assignments don't throw
+  // and there are no leaks.
+  read_end.close();
+  write_end.close();
+  int fds[2] = {};
+#ifdef _WIN32
+  // Make the default pipe capacity same as on Linux 2.6.11+.
+  enum { DEFAULT_CAPACITY = 65536 };
+  int result = FMT_POSIX_CALL(pipe(fds, DEFAULT_CAPACITY, _O_BINARY));
+#else
+  // Don't retry as the pipe function doesn't return EINTR.
+  // http://pubs.opengroup.org/onlinepubs/009696799/functions/pipe.html
+  int result = FMT_POSIX_CALL(pipe(fds));
+#endif
+  if (result != 0)
+    FMT_THROW(system_error(errno, "cannot create pipe"));
+  // The following assignments don't throw because read_fd and write_fd
+  // are closed.
+  read_end = File(fds[0]);
+  write_end = File(fds[1]);
+}
+
+fmt::BufferedFile fmt::File::fdopen(const char *mode) {
+  // Don't retry as fdopen doesn't return EINTR.
+  FILE *f = FMT_POSIX_CALL(fdopen(fd_, mode));
+  if (!f)
+    FMT_THROW(system_error(errno,
+                           "cannot associate stream with file descriptor"));
+  BufferedFile file(f);
+  fd_ = -1;
+  return file;
+}
+
+long fmt::getpagesize() {
+#ifdef _WIN32
+  SYSTEM_INFO si;
+  GetSystemInfo(&si);
+  return si.dwPageSize;
+#else
+  long size = FMT_POSIX_CALL(sysconf(_SC_PAGESIZE));
+  if (size < 0)
+    FMT_THROW(system_error(errno, "cannot get memory page size"));
+  return size;
+#endif
+}

--- a/src/fd_watcher.cpp
+++ b/src/fd_watcher.cpp
@@ -9,19 +9,12 @@
 #include <sys/types.h>
 #include <sys/select.h>
 
+#include <fmt/format.h>
 
-static std::runtime_error error(const char* fmt, ...)
+template<typename... Args>
+std::runtime_error error(const char* fmt, const Args& ... args)
 {
-	va_list args;
-	va_start(args, fmt);
-
-	char str[1024];
-
-	vsnprintf(str, sizeof(str), fmt, args);
-
-	va_end(args);
-
-	return std::runtime_error(str);
+	return std::runtime_error(fmt::format(fmt, args...));
 }
 
 namespace rosmon
@@ -63,7 +56,7 @@ void FDWatcher::wait(const ros::WallDuration& duration)
 		if(errno == EINTR || errno == EAGAIN)
 			return;
 
-		throw error("Could not select(): %s", strerror(errno));
+		throw error("Could not select(): {}", strerror(errno));
 	}
 
 	if(ret != 0)

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -27,7 +27,7 @@ namespace launch
 
 const char* UNSET_MARKER = "~~~~~ ROSMON-UNSET ~~~~~";
 
-static LaunchConfig::ParseException error(const char* fmt, ...)
+static ParseException error(const char* fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
@@ -38,7 +38,7 @@ static LaunchConfig::ParseException error(const char* fmt, ...)
 
 	va_end(args);
 
-	return LaunchConfig::ParseException(str);
+	return ParseException(str);
 }
 
 /**

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -27,20 +27,6 @@ namespace launch
 
 const char* UNSET_MARKER = "~~~~~ ROSMON-UNSET ~~~~~";
 
-static ParseException error(const char* fmt, ...)
-{
-	va_list args;
-	va_start(args, fmt);
-
-	char str[1024];
-
-	vsnprintf(str, sizeof(str), fmt, args);
-
-	va_end(args);
-
-	return ParseException(str);
-}
-
 /**
  * @brief Compress any sequence of whitespace to single spaces.
  *
@@ -113,7 +99,7 @@ std::string ParseContext::evaluate(const std::string& tpl, bool simplifyWhitespa
 	}
 	catch(SubstitutionException& e)
 	{
-		throw error("%s: %s", filename().c_str(), e.what());
+		throw error("Substitution error: {}", e.what());
 	}
 }
 
@@ -133,7 +119,7 @@ bool ParseContext::parseBool(const std::string& value, int line)
 	if(expansion == "0" || expansion == "false" || expansion == "False")
 		return false;
 
-	throw error("%s:%d: Unknown truth value '%s'", filename().c_str(), line, expansion.c_str());
+	throw error("Unknown truth value '%s'", expansion.c_str());
 }
 
 bool ParseContext::shouldSkip(TiXmlElement* e)
@@ -143,9 +129,7 @@ bool ParseContext::shouldSkip(TiXmlElement* e)
 
 	if(if_cond && unless_cond)
 	{
-		throw error("%s:%d: both if= and unless= specified, don't know what to do",
-			filename().c_str(), e->Row()
-		);
+		throw error("both if= and unless= specified, don't know what to do");
 	}
 
 	if(if_cond)
@@ -188,28 +172,31 @@ void LaunchConfig::setArgument(const std::string& name, const std::string& value
 
 void LaunchConfig::parse(const std::string& filename, bool onlyArguments)
 {
+	m_rootContext.setFilename(filename);
+
 	TiXmlDocument document(filename);
 
 	TiXmlBase::SetCondenseWhiteSpace(false);
 
 	if(!document.LoadFile())
 	{
-		throw error("Could not load launch file '%s'. Exiting...\n", filename.c_str());
+		throw m_rootContext.error("Could not load launch file: {}", document.ErrorDesc());
 	}
 
 	ros::WallTime start = ros::WallTime::now();
-	m_rootContext.setFilename(filename);
 	parse(document.RootElement(), &m_rootContext, onlyArguments);
 
 	// Parse top-level rosmon-specific attributes
 	parseTopLevelAttributes(document.RootElement());
 
 	if(!onlyArguments)
-		printf("Loaded launch file in %fs\n", (ros::WallTime::now() - start).toSec());
+		fmt::print("Loaded launch file in {:f}s\n", (ros::WallTime::now() - start).toSec());
 }
 
 void LaunchConfig::parseString(const std::string& input, bool onlyArguments)
 {
+	m_rootContext.setFilename("[string]");
+
 	TiXmlDocument document;
 
 	TiXmlBase::SetCondenseWhiteSpace(false);
@@ -218,18 +205,17 @@ void LaunchConfig::parseString(const std::string& input, bool onlyArguments)
 
 	if(document.Error())
 	{
-		throw error("Could not parse string input: %s\n", document.ErrorDesc());
+		throw m_rootContext.error("Could not parse string input: {}", document.ErrorDesc());
 	}
 
 	ros::WallTime start = ros::WallTime::now();
-	m_rootContext.setFilename("[string]");
 	parse(document.RootElement(), &m_rootContext, onlyArguments);
 
 	// Parse top-level rosmon-specific attributes
 	parseTopLevelAttributes(document.RootElement());
 
 	if(!onlyArguments)
-		printf("Loaded launch file in %fs\n", (ros::WallTime::now() - start).toSec());
+		fmt::print("Loaded launch file in {:f}s\n", (ros::WallTime::now() - start).toSec());
 }
 
 void LaunchConfig::parseTopLevelAttributes(TiXmlElement* element)
@@ -317,9 +303,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 
 	if(!name || !pkg || !type)
 	{
-		throw error("File %s:%d: name, pkg, type are mandatory for node elements!\n",
-			ctx.filename().c_str(), element->Row()
-		);
+		throw ctx.error("name, pkg, type are mandatory for node elements!");
 	}
 
 	if(ns)
@@ -342,9 +326,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 
 		if(it != m_nodes.end())
 		{
-			throw error("%s:%d: node name '%s' is not unique",
-				ctx.filename().c_str(), element->Row(), node->name().c_str()
-			);
+			throw ctx.error("node name '{}' is not unique", node->name());
 		}
 	}
 
@@ -367,7 +349,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 			}
 			catch(boost::bad_lexical_cast&)
 			{
-				throw error("%s:%d: bad respawn_delay value", ctx.filename().c_str(), element->Row());
+				throw ctx.error("bad respawn_delay value '{}'", respawnDelay);
 			}
 
 			node->setRespawnDelay(ros::WallDuration(seconds));
@@ -400,7 +382,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 			const char* to = e->Attribute("to");
 
 			if(!from || !to)
-				throw error("%s:%d: remap needs 'from' and 'to' arguments", ctx.filename().c_str(), e->Row());
+				throw ctx.error("remap needs 'from' and 'to' arguments");
 
 			node->addRemapping(ctx.evaluate(from), ctx.evaluate(to));
 		}
@@ -455,23 +437,15 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 	const char* binfile = element->Attribute("binfile");
 	const char* type = element->Attribute("type");
 
-	// Filename and line for error reporting
-	std::string filename = ctx.filename();
-	int line = element->Row();
-
 	if(!name)
 	{
-		throw error("File %s:%d: name is mandatory for param elements\n",
-			ctx.filename().c_str(), element->Row()
-		);
+		throw ctx.error("name is mandatory for param elements");
 	}
 
 	int numCommands = (value ? 1 : 0) + (command ? 1 : 0) + (textfile ? 1 : 0) + (binfile ? 1 : 0);
 	if(numCommands > 1) // == 0 is checked below, don't duplicate.
 	{
-		throw error("File %s:%d: <param> tags need exactly one of value=, command=, textfile=, binfile= attributes.",
-			filename.c_str(), line
-		);
+		throw ctx.error("<param> tags need exactly one of value=, command=, textfile=, binfile= attributes.");
 	}
 
 	std::string fullName = ctx.evaluate(name);
@@ -489,9 +463,8 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 	std::string errorStr;
 	if(!ros::names::validate(fullName, errorStr))
 	{
-		throw error("File %s:%d: expanded parameter name '%s' is invalid: %s\n",
-			ctx.filename().c_str(), element->Row(),
-			fullName.c_str(), errorStr.c_str()
+		throw ctx.error("Expanded parameter name '{}' is invalid: {}",
+			fullName, errorStr
 		);
 	}
 
@@ -513,16 +486,14 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 			}
 			catch(YAML::ParserException& e)
 			{
-				throw error("%s:%d: Invalid YAML: %s",
-					ctx.filename().c_str(), element->Row(), e.what()
-				);
+				throw ctx.error("Invalid YAML: {}", e.what());
 			}
 
-			loadYAMLParams(n, fullName);
+			loadYAMLParams(ctx, n, fullName);
 		}
 		else
 		{
-			m_params[fullName] = paramToXmlRpc(ctx.filename(), element->Row(), ctx.evaluate(value), fullType);
+			m_params[fullName] = paramToXmlRpc(ctx, ctx.evaluate(value), fullType);
 
 			// A dynamic parameter of the same name gets overwritten now
 			m_paramJobs.erase(fullName);
@@ -541,7 +512,7 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 			[=]() -> XmlRpc::XmlRpcValue {
 				std::ifstream stream(fullFile, std::ios::binary | std::ios::ate);
 				if(stream.bad())
-					throw error("%s:%d: Could not open file '%s'", ctx.filename().c_str(), element->Row(), fullFile.c_str());
+					throw ctx.error("Could not open file '{}'", fullFile);
 
 				std::vector<char> data(stream.tellg(), 0);
 				stream.seekg(0, std::ios::beg);
@@ -577,11 +548,11 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 
 				int pipe_fd[2];
 				if(pipe(pipe_fd) != 0)
-					throw error("Could not create pipe: %s", strerror(errno));
+					throw ctx.error("Could not create pipe: {}", strerror(errno));
 
 				int pid = fork();
 				if(pid < 0)
-					throw error("Could not fork: %s", strerror(errno));
+					throw ctx.error("Could not fork: {}", strerror(errno));
 
 				if(pid == 0)
 				{
@@ -596,7 +567,7 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 					char* argp[] = {strdup("sh"), strdup("-c"), strdup(fullCommand.c_str()), nullptr};
 
 					execvp("sh", argp); // should never return
-					throw error("Could not execvp '%s': %s", fullCommand.c_str(), strerror(errno));
+					throw ctx.error("Could not execvp '{}': {}", fullCommand, strerror(errno));
 				}
 
 				close(pipe_fd[1]);
@@ -614,11 +585,11 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 
 					int ret = select(pipe_fd[0]+1, &fds, nullptr, nullptr, &timeout);
 					if(ret < 0)
-						throw error("Could not select(): %s", strerror(errno));
+						throw ctx.error("Could not select(): {}", strerror(errno));
 
 					if(ret == 0)
 					{
-						printf("Still loading parameter '%s'...\n", fullName.c_str());
+						fmt::print("Still loading parameter '{}'...\n", fullName);
 
 						timeout.tv_sec = 3;
 						continue;
@@ -627,7 +598,7 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 					char buf[1024];
 					ret = read(pipe_fd[0], buf, sizeof(buf)-1);
 					if(ret < 0)
-						throw error("Could not read: %s", strerror(errno));
+						throw ctx.error("Could not read: {}", strerror(errno));
 					if(ret == 0)
 						break;
 
@@ -639,12 +610,12 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 
 				int status = 0;
 				if(waitpid(pid, &status, 0) < 0)
-					throw error("Could not waitpid(): %s", strerror(errno));
+					throw ctx.error("Could not waitpid(): {}", strerror(errno));
 
 				if(!WIFEXITED(status) || WEXITSTATUS(status) != 0)
 				{
-					throw error("%s:%d: <param> command failed (exit status %d)",
-						filename.c_str(), line, status
+					throw ctx.error("<param> command failed (exit status {})",
+						WEXITSTATUS(status)
 					);
 				}
 
@@ -663,7 +634,7 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 			[=]() -> std::string {
 				std::ifstream stream(fullFile);
 				if(stream.bad())
-					throw error("%s:%d: Could not open file '%s'", ctx.filename().c_str(), element->Row(), fullFile.c_str());
+					throw ctx.error("Could not open file '{}'", fullFile);
 
 				std::stringstream buffer;
 				buffer << stream.rdbuf();
@@ -674,9 +645,7 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 	}
 	else
 	{
-		throw error("%s:%d: <param> needs either command, value, binfile, or textfile",
-			ctx.filename().c_str(), element->Row()
-		);
+		throw ctx.error("<param> needs either command, value, binfile, or textfile");
 	}
 
 	if(fullType == "yaml")
@@ -692,8 +661,8 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 				}
 				catch(YAML::ParserException& e)
 				{
-					throw error("%s:%d: Read invalid YAML from process or file: %s",
-						filename.c_str(), line, e.what()
+					throw ctx.error("Read invalid YAML from process or file: {}",
+						e.what()
 					);
 				}
 
@@ -705,7 +674,7 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 	{
 		m_paramJobs[fullName] = std::async(std::launch::deferred,
 			[=]() -> XmlRpc::XmlRpcValue {
-				return paramToXmlRpc(filename, line, computeString->get(), fullType);
+				return paramToXmlRpc(ctx, computeString->get(), fullType);
 			}
 		);
 
@@ -714,7 +683,7 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 	}
 }
 
-XmlRpc::XmlRpcValue LaunchConfig::paramToXmlRpc(const std::string& filename, int line, const std::string& value, const std::string& type)
+XmlRpc::XmlRpcValue LaunchConfig::paramToXmlRpc(const ParseContext& ctx, const std::string& value, const std::string& type)
 {
 	if(type.empty())
 		return autoXmlRpcValue(value);
@@ -734,24 +703,20 @@ XmlRpc::XmlRpcValue LaunchConfig::paramToXmlRpc(const std::string& filename, int
 				return false;
 			else
 			{
-				throw error("%s:%d: invalid boolean value '%s'",
-					filename.c_str(), line, value.c_str()
-				);
+				throw ctx.error("invalid boolean value '{}'", value);
 			}
 		}
 		else if(type == "str" || type == "string")
 			return value;
 		else
 		{
-			throw error("%s:%d: invalid param type '%s'",
-				filename.c_str(), line, type.c_str()
-			);
+			throw ctx.error("invalid param type '{}'", type);
 		}
 	}
 	catch(boost::bad_lexical_cast& e)
 	{
-		throw error("%s:%d: could not convert param value '%s' to type '%s'",
-			filename.c_str(), line, value.c_str(), type.c_str()
+		throw ctx.error("could not convert param value '{}' to type '{}'",
+			value, type
 		);
 	}
 }
@@ -771,7 +736,7 @@ void LaunchConfig::parseROSParam(TiXmlElement* element, ParseContext ctx)
 			fullFile = ctx.evaluate(file);
 			std::ifstream stream(fullFile);
 			if(stream.bad())
-				throw error("%s:%d: Could not open file '%s'", ctx.filename().c_str(), element->Row(), fullFile.c_str());
+				throw ctx.error("Could not open file '{}'", fullFile);
 
 			std::stringstream buffer;
 			buffer << stream.rdbuf();
@@ -800,7 +765,7 @@ void LaunchConfig::parseROSParam(TiXmlElement* element, ParseContext ctx)
 		}
 		catch(YAML::ParserException& e)
 		{
-			throw error("%s:%d: Could not parse YAML: %s", ctx.filename().c_str(), element->Row(), e.what());
+			throw ctx.error("Could not parse YAML: {}", e.what());
 		}
 
 		const char* ns = element->Attribute("ns");
@@ -814,23 +779,26 @@ void LaunchConfig::parseROSParam(TiXmlElement* element, ParseContext ctx)
 		// Remove trailing / from prefix to get param name
 		try
 		{
-			loadYAMLParams(n, ctx.prefix().substr(0, ctx.prefix().length()-1));
+			loadYAMLParams(ctx, n, ctx.prefix().substr(0, ctx.prefix().length()-1));
 		}
 		catch(ParseException& e)
 		{
-			std::stringstream ss;
-			ss << ctx.filename() << ": ";
 			if(file)
-				ss << "Error while parsing rosparam input file '" << fullFile << "': ";
+			{
+				throw ctx.error("error while parsing rosparam input file {}: {}",
+					fullFile, e.what()
+				);
+			}
 			else
-				ss << "Error while parsing YAML input from launch file: ";
-
-			ss << e.what();
-			throw ParseException(ss.str());
+			{
+				throw ctx.error("error while parsing YAML input from launch file: {}",
+					e.what()
+				);
+			}
 		}
 	}
 	else
-		throw error("Unsupported rosparam command '%s'", command);
+		throw ctx.error("Unsupported rosparam command '{}'", command);
 }
 
 
@@ -856,7 +824,7 @@ public:
 };
 
 
-XmlRpc::XmlRpcValue LaunchConfig::yamlToXmlRpc(const YAML::Node& n)
+XmlRpc::XmlRpcValue LaunchConfig::yamlToXmlRpc(const ParseContext& ctx, const YAML::Node& n)
 {
 	if(n.Type() != YAML::NodeType::Scalar)
 	{
@@ -867,7 +835,7 @@ XmlRpc::XmlRpcValue LaunchConfig::yamlToXmlRpc(const YAML::Node& n)
 				std::map<std::string, XmlRpc::XmlRpcValue> members;
 				for(YAML::const_iterator it = n.begin(); it != n.end(); ++it)
 				{
-					members[it->first.as<std::string>()] = yamlToXmlRpc(it->second);
+					members[it->first.as<std::string>()] = yamlToXmlRpc(ctx, it->second);
 				}
 				return XmlRpcValueCreator::createStruct(members);
 			}
@@ -876,12 +844,12 @@ XmlRpc::XmlRpcValue LaunchConfig::yamlToXmlRpc(const YAML::Node& n)
 				std::vector<XmlRpc::XmlRpcValue> values;
 				for(YAML::const_iterator it = n.begin(); it != n.end(); ++it)
 				{
-					values.push_back(yamlToXmlRpc(*it));
+					values.push_back(yamlToXmlRpc(ctx, *it));
 				}
 				return XmlRpcValueCreator::createArray(values);
 			}
 			default:
-				throw error("Invalid YAML node type");
+				throw ctx.error("Invalid YAML node type");
 		}
 	}
 
@@ -909,10 +877,10 @@ XmlRpc::XmlRpcValue LaunchConfig::yamlToXmlRpc(const YAML::Node& n)
 	try { return XmlRpc::XmlRpcValue(n.as<std::string>()); }
 	catch(YAML::Exception&) {}
 
-	throw error("Could not convert YAML value");
+	throw ctx.error("Could not convert YAML value");
 }
 
-void LaunchConfig::loadYAMLParams(const YAML::Node& n, const std::string& prefix)
+void LaunchConfig::loadYAMLParams(const ParseContext& ctx, const YAML::Node& n, const std::string& prefix)
 {
 	switch(n.Type())
 	{
@@ -920,14 +888,14 @@ void LaunchConfig::loadYAMLParams(const YAML::Node& n, const std::string& prefix
 		{
 			for(YAML::const_iterator it = n.begin(); it != n.end(); ++it)
 			{
-				loadYAMLParams(it->second, prefix + "/" + it->first.as<std::string>());
+				loadYAMLParams(ctx, it->second, prefix + "/" + it->first.as<std::string>());
 			}
 			break;
 		}
 		case YAML::NodeType::Sequence:
 		case YAML::NodeType::Scalar:
 		{
-			m_params[prefix] = yamlToXmlRpc(n);
+			m_params[prefix] = yamlToXmlRpc(ctx, n);
 
 			// A dynamic parameter of the same name gets overwritten now
 			m_paramJobs.erase(prefix);
@@ -935,7 +903,7 @@ void LaunchConfig::loadYAMLParams(const YAML::Node& n, const std::string& prefix
 		}
 		default:
 		{
-			throw error("invalid yaml node type");
+			throw ctx.error("invalid yaml node type");
 		}
 	}
 }
@@ -948,13 +916,11 @@ void LaunchConfig::parseInclude(TiXmlElement* element, ParseContext ctx)
 	const char* clearParams = element->Attribute("clear_params");
 
 	if(!file)
-		throw error("%s:%d: file attribute is mandatory", ctx.filename().c_str(), element->Row());
+		throw ctx.error("<include> file attribute is mandatory");
 
 	if(clearParams && ctx.parseBool(clearParams, element->Row()))
 	{
-		throw error("%s:%d: <include clear_params=\"true\" /> is not supported and probably a bad idea.",
-			ctx.filename().c_str(), element->Row()
-		);
+		throw ctx.error("<include clear_params=\"true\" /> is not supported and probably a bad idea.");
 	}
 
 	std::string fullFile = ctx.evaluate(file);
@@ -985,7 +951,7 @@ void LaunchConfig::parseInclude(TiXmlElement* element, ParseContext ctx)
 			const char* value = e->Attribute("value");
 
 			if(!name || !value)
-				throw error("%s:%d: <arg> inside include needs name and value", ctx.filename().c_str(), element->Row());
+				throw ctx.error("<arg> inside include needs name and value");
 
 			childCtx.setArg(ctx.evaluate(name), ctx.evaluate(value), true);
 		}
@@ -993,7 +959,7 @@ void LaunchConfig::parseInclude(TiXmlElement* element, ParseContext ctx)
 
 	TiXmlDocument document(fullFile);
 	if(!document.LoadFile())
-		throw error("Could not load launch file '%s'. Exiting...\n", fullFile.c_str());
+		throw ctx.error("Could not load launch file '{}': {}", fullFile, document.ErrorDesc());
 
 	childCtx.setFilename(fullFile);
 
@@ -1007,7 +973,7 @@ void LaunchConfig::parseArgument(TiXmlElement* element, ParseContext& ctx)
 	const char* def = element->Attribute("default");
 
 	if(!name)
-		throw error("%s:%d: <arg> needs name attribute", ctx.filename().c_str(), element->Row());
+		throw ctx.error("<arg> needs name attribute");
 
 	if(value)
 	{
@@ -1031,7 +997,7 @@ void LaunchConfig::parseEnv(TiXmlElement* element, ParseContext& ctx)
 	const char* value = element->Attribute("value");
 
 	if(!name || !value)
-		throw error("%s:%d: <env> needs name, value attributes", ctx.filename().c_str(), element->Row());
+		throw ctx.error("<env> needs name, value attributes");
 
 	ctx.setEnvironment(ctx.evaluate(name), ctx.evaluate(value));
 }
@@ -1114,7 +1080,7 @@ void LaunchConfig::evaluateParameters()
 					YAMLResult yaml = yamlIt->get();
 					{
 						std::lock_guard<std::mutex> guard(mutex);
-						loadYAMLParams(yaml.yaml, yaml.name);
+						loadYAMLParams(m_rootContext, yaml.yaml, yaml.name);
 					}
 					safeAdvance(yamlIt, m_yamlParamJobs.end(), NUM_THREADS);
 				}

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -666,7 +666,7 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx)
 					);
 				}
 
-				return {fullName, std::move(n)};
+				return {fullName, n};
 			}
 		));
 	}

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -255,6 +255,8 @@ void LaunchConfig::parse(TiXmlElement* element, ParseContext* ctx, bool onlyArgu
 		if(ctx->shouldSkip(e))
 			continue;
 
+		ctx->setCurrentElement(e);
+
 		if(e->ValueStr() == "arg")
 			parseArgument(e, *ctx);
 	}
@@ -271,6 +273,8 @@ void LaunchConfig::parse(TiXmlElement* element, ParseContext* ctx, bool onlyArgu
 
 		if(ctx->shouldSkip(e))
 			continue;
+
+		ctx->setCurrentElement(e);
 
 		if(e->ValueStr() == "node")
 			parseNode(e, *ctx);
@@ -384,6 +388,8 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 		if(ctx.shouldSkip(e))
 			continue;
 
+		ctx.setCurrentElement(e);
+
 		if(e->ValueStr() == "param")
 			parseParam(e, ctx);
 		else if(e->ValueStr() == "rosparam")
@@ -401,6 +407,8 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 		else if(e->ValueStr() == "env")
 			parseEnv(e, ctx);
 	}
+
+	ctx.setCurrentElement(element);
 
 	// Set environment *after* parsing the node children (may contain env tags)
 	node->setExtraEnvironment(ctx.environment());

--- a/src/launch/launch_config.h
+++ b/src/launch/launch_config.h
@@ -23,6 +23,22 @@ namespace launch
 
 class LaunchConfig;
 
+class ParseException : public std::exception
+{
+public:
+	explicit ParseException(const std::string& msg)
+		: m_msg(msg)
+	{}
+
+	virtual ~ParseException() throw()
+	{}
+
+	virtual const char* what() const noexcept
+	{ return m_msg.c_str(); }
+private:
+	std::string m_msg;
+};
+
 extern const char* UNSET_MARKER;
 
 class ParseContext
@@ -89,22 +105,6 @@ class LaunchConfig
 public:
 	typedef std::shared_ptr<LaunchConfig> Ptr;
 	typedef std::shared_ptr<const LaunchConfig> ConstPtr;
-
-	class ParseException : public std::exception
-	{
-	public:
-		explicit ParseException(const std::string& msg)
-		 : m_msg(msg)
-		{}
-
-		virtual ~ParseException() throw()
-		{}
-
-		virtual const char* what() const noexcept
-		{ return m_msg.c_str(); }
-	private:
-		std::string m_msg;
-	};
 
 	LaunchConfig();
 

--- a/src/launch/launch_config.h
+++ b/src/launch/launch_config.h
@@ -16,6 +16,8 @@
 #include <tinyxml.h>
 #include <yaml-cpp/yaml.h>
 
+#include <fmt/format.h>
+
 namespace rosmon
 {
 namespace launch
@@ -35,6 +37,12 @@ public:
 
 	virtual const char* what() const noexcept
 	{ return m_msg.c_str(); }
+
+	template<typename... Args>
+	ParseException format(const char* format, const Args& ... args)
+	{
+		return ParseException(fmt::format(format, args...));
+	}
 private:
 	std::string m_msg;
 };
@@ -59,7 +67,15 @@ public:
 	{ m_filename = filename; }
 
 	void setCurrentElement(TiXmlElement* e)
-	{ m_currentElement = e; }
+	{
+		// NOTE: We should not keep a reference to the TiXmlElement here,
+		// since the ParseContext might be around longer than the DOM tree.
+		// See evaluateParameters().
+		if(e)
+			m_currentLine = e->Row();
+		else
+			m_currentLine = -1;
+	}
 
 	ParseContext enterScope(const std::string& prefix)
 	{
@@ -94,12 +110,29 @@ public:
 
 	inline LaunchConfig* config()
 	{ return m_config; }
+
+	template<typename... Args>
+	ParseException error(const char* fmt, const Args& ... args) const
+	{
+		std::string msg = fmt::format(fmt, args...);
+
+		if(m_currentLine >= 0)
+		{
+			return ParseException(fmt::format("{}:{}: {}",
+				m_filename, m_currentLine, msg
+			));
+		}
+		else
+		{
+			return ParseException(fmt::format("{}: {}", m_filename, msg));
+		}
+	}
 private:
 	LaunchConfig* m_config;
 
 	std::string m_prefix;
 	std::string m_filename;
-	TiXmlElement* m_currentElement = 0;
+	int m_currentLine = -1;
 	std::map<std::string, std::string> m_args;
 	std::map<std::string, std::string> m_environment;
 };
@@ -146,10 +179,10 @@ private:
 	void parseArgument(TiXmlElement* element, ParseContext& ctx);
 	void parseEnv(TiXmlElement* element, ParseContext& ctx);
 
-	void loadYAMLParams(const YAML::Node& n, const std::string& prefix);
+	void loadYAMLParams(const ParseContext& ctx, const YAML::Node& n, const std::string& prefix);
 
-	XmlRpc::XmlRpcValue paramToXmlRpc(const std::string& filename, int line, const std::string& value, const std::string& type = "");
-	XmlRpc::XmlRpcValue yamlToXmlRpc(const YAML::Node& n);
+	XmlRpc::XmlRpcValue paramToXmlRpc(const ParseContext& ctx, const std::string& value, const std::string& type = "");
+	XmlRpc::XmlRpcValue yamlToXmlRpc(const ParseContext& ctx, const YAML::Node& n);
 
 	ParseContext m_rootContext;
 

--- a/src/launch/launch_config.h
+++ b/src/launch/launch_config.h
@@ -58,6 +58,9 @@ public:
 	void setFilename(const std::string& filename)
 	{ m_filename = filename; }
 
+	void setCurrentElement(TiXmlElement* e)
+	{ m_currentElement = e; }
+
 	ParseContext enterScope(const std::string& prefix)
 	{
 		ParseContext ret = *this;
@@ -96,6 +99,7 @@ private:
 
 	std::string m_prefix;
 	std::string m_filename;
+	TiXmlElement* m_currentElement = 0;
 	std::map<std::string, std::string> m_args;
 	std::map<std::string, std::string> m_environment;
 };

--- a/src/launch/node.cpp
+++ b/src/launch/node.cpp
@@ -10,18 +10,13 @@
 
 #include <cstdarg>
 
-static std::runtime_error error(const char* fmt, ...)
+#include <fmt/format.h>
+
+template<typename... Args>
+std::runtime_error error(const char* format, const Args& ... args)
 {
-	va_list args;
-	va_start(args, fmt);
-
-	char str[1024];
-
-	vsnprintf(str, sizeof(str), fmt, args);
-
-	va_end(args);
-
-	return std::runtime_error(str);
+	std::string msg = fmt::format(format, args...);
+	return std::runtime_error(msg);
 }
 
 namespace rosmon
@@ -69,7 +64,7 @@ void Node::addExtraArguments(const std::string& argString)
 	//   any case), I think we can use wordexp here.
 	int ret = wordexp(clean.c_str(), &tokens, WRDE_NOCMD);
 	if(ret != 0)
-		throw error("You're supplying something strange in 'args': '%s' (wordexp ret %d)", clean.c_str(), ret);
+		throw error("You're supplying something strange in 'args': '{}' (wordexp ret {})", clean, ret);
 
 	for(unsigned int i = 0; i < tokens.we_wordc; ++i)
 		m_extraArgs.emplace_back(tokens.we_wordv[i]);
@@ -119,7 +114,7 @@ void Node::setLaunchPrefix(const std::string& launchPrefix)
 	//   any case), I think we can use wordexp here.
 	int ret = wordexp(clean.c_str(), &tokens, WRDE_NOCMD);
 	if(ret != 0)
-		throw error("You're supplying something strange in 'launch-prefix': '%s' (wordexp ret %d)", clean.c_str(), ret);
+		throw error("You're supplying something strange in 'launch-prefix': '{}' (wordexp ret {})", clean, ret);
 
 	for(unsigned int i = 0; i < tokens.we_wordc; ++i)
 		m_launchPrefix.emplace_back(tokens.we_wordv[i]);

--- a/src/launch/substitution.cpp
+++ b/src/launch/substitution.cpp
@@ -183,7 +183,7 @@ std::string parseSubstitutionArgs(const std::string& input, ParseContext& contex
 			return substitutions::env(args);
 		}},
 		{"optenv", [](const std::string& args, const std::string&) -> std::string{
-			auto pos = args.find(" ");
+			auto pos = args.find(' ');
 			std::string defaultValue;
 			std::string name = args;
 			if(pos != std::string::npos)

--- a/src/launch/substitution.cpp
+++ b/src/launch/substitution.cpp
@@ -29,20 +29,6 @@ enum ParserState
 	PARSER_INSIDE,
 };
 
-static SubstitutionException error(const char* fmt, ...)
-{
-	va_list args;
-	va_start(args, fmt);
-
-	char str[1024];
-
-	vsnprintf(str, sizeof(str), fmt, args);
-
-	va_end(args);
-
-	return SubstitutionException(str);
-}
-
 namespace substitutions
 {
 	std::string anon(const std::string& name, ParseContext& context)
@@ -57,14 +43,14 @@ namespace substitutions
 	{
 		auto it = context.arguments().find(name);
 		if(it == context.arguments().end())
-			throw error("$(arg %s): Unknown arg", name.c_str());
+			throw SubstitutionException::format("$(arg {}): Unknown arg", name);
 
 		std::string value = it->second;
 
 		if(value == UNSET_MARKER)
 		{
-			throw error(
-				"$(arg %s): Accessing unset argument '%s', please specify as parameter.", name.c_str(), name.c_str()
+			throw SubstitutionException::format(
+				"$(arg {}): Accessing unset argument '{}', please specify as parameter.", name, name
 			);
 		}
 
@@ -81,7 +67,7 @@ namespace substitutions
 	{
 		const char* envval = getenv(name.c_str());
 		if(!envval)
-			throw error("$(env %s): Environment variable not set!", name.c_str());
+			throw SubstitutionException::format("$(env {}): Environment variable not set!", name);
 
 		return envval;
 	}
@@ -101,7 +87,7 @@ namespace substitutions
 		if(!path.empty())
 			return path;
 
-		throw error("$(find %s): Could not find package", name.c_str());
+		throw SubstitutionException::format("$(find {}): Could not find package", name);
 	}
 }
 
@@ -159,7 +145,7 @@ static std::string parseOneElement(const std::string& input, const HandlerMap& h
 
 					if(strict)
 					{
-						throw error("Unknown substitution arg '%s'", name.c_str());
+						throw SubstitutionException::format("Unknown substitution arg '{}'", name);
 					}
 
 					state = PARSER_IDLE;
@@ -235,7 +221,7 @@ std::string parseSubstitutionArgs(const std::string& input, ParseContext& contex
 			if(!path.empty())
 				return path;
 
-			throw error("$(find %s): Could not find package", args.c_str());
+			throw SubstitutionException::format("$(find {}): Could not find package", args);
 		}},
 	};
 

--- a/src/launch/substitution.h
+++ b/src/launch/substitution.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <stdexcept>
 
+#include <fmt/format.h>
+
 namespace rosmon
 {
 namespace launch
@@ -26,6 +28,12 @@ public:
 
 	virtual const char* what() const noexcept override
 	{ return m_msg.c_str(); }
+
+	template<typename... Args>
+	static SubstitutionException format(const char* format, const Args& ... args)
+	{
+		return SubstitutionException(fmt::format(format, args...));
+	}
 private:
 	std::string m_msg;
 };

--- a/src/launch/substitution_python.cpp
+++ b/src/launch/substitution_python.cpp
@@ -21,20 +21,6 @@ namespace rosmon
 namespace launch
 {
 
-static SubstitutionException error(const char* fmt, ...)
-{
-	va_list args;
-	va_start(args, fmt);
-
-	char str[1024];
-
-	vsnprintf(str, sizeof(str), fmt, args);
-
-	va_end(args);
-
-	return SubstitutionException(str);
-}
-
 #if HAVE_PYTHON
 
 template<class F>
@@ -171,7 +157,7 @@ std::string evaluatePython(const std::string& input, ParseContext& context)
 			ss << "<no str() handler>";
 		}
 
-		throw error("%s", ss.str().c_str());
+		throw SubstitutionException(ss.str());
 	}
 
 	if(PyString_Check(result.ptr()))
@@ -198,7 +184,7 @@ std::string evaluatePython(const std::string& input, ParseContext& context)
 		);
 	}
 
-	throw error("$(eval '%s'): Got unknown python return type", input.c_str());
+	throw SubstitutionException::format("$(eval '{}'): Got unknown python return type", input);
 }
 
 #else // HAVE_PYTHON

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -7,10 +7,11 @@
 #include <cstdio>
 #include <cstring>
 #include <ctime>
-#include <sstream>
 #include <stdexcept>
 
 #include <sys/time.h>
+
+#include <fmt/format.h>
 
 namespace rosmon
 {
@@ -21,9 +22,9 @@ Logger::Logger(const std::string& path)
 	m_file = fopen(path.c_str(), "we");
 	if(!m_file)
 	{
-		std::stringstream ss;
-		ss << "Could not open log file: " << strerror(errno);
-		throw std::runtime_error(ss.str());
+		throw std::runtime_error(fmt::format(
+			"Could not open log file: {}", strerror(errno)
+		));
 	}
 }
 
@@ -50,7 +51,7 @@ void Logger::log(const std::string& source, const std::string& msg)
 	while(len != 0 && (msg[len-1] == '\n' || msg[len-1] == '\r'))
 		len--;
 
-	fprintf(m_file, "%s.%03ld: %20s: ",
+	fmt::print(m_file, "{}.{:03d}: {:>20}: ",
 		timeString, tv.tv_usec / 1000,
 		source.c_str()
 	);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -257,7 +257,7 @@ int main(int argc, char** argv)
 		config->parse(launchFilePath, onlyArguments);
 		config->evaluateParameters();
 	}
-	catch(rosmon::launch::LaunchConfig::ParseException& e)
+	catch(rosmon::launch::ParseException& e)
 	{
 		fprintf(stderr, "Could not load launch file: %s\n", e.what());
 		return 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,14 +9,6 @@
 #include <ros/console_backend.h>
 #include <ros/this_node.h>
 
-#include "launch/launch_config.h"
-#include "monitor/monitor.h"
-#include "ui.h"
-#include "ros_interface.h"
-#include "package_registry.h"
-#include "fd_watcher.h"
-#include "logger.h"
-
 #include <boost/filesystem.hpp>
 
 #include <unistd.h>
@@ -24,6 +16,16 @@
 #include <csignal>
 
 #include <iostream>
+
+#include <fmt/format.h>
+
+#include "launch/launch_config.h"
+#include "monitor/monitor.h"
+#include "ui.h"
+#include "ros_interface.h"
+#include "package_registry.h"
+#include "fd_watcher.h"
+#include "logger.h"
 
 namespace fs = boost::filesystem;
 
@@ -86,7 +88,7 @@ void logToStdout(const std::string& channel, const std::string& str)
 
 	clean.resize(len);
 
-	printf("%20s: %s\n", channel.c_str(), clean.c_str());
+	fmt::print("{:>20}: {}\n", channel, clean);
 }
 
 // Options
@@ -177,14 +179,14 @@ int main(int argc, char** argv)
 		std::string package = rosmon::PackageRegistry::getPath(packageName);
 		if(package.empty())
 		{
-			fprintf(stderr, "Could not find path of package '%s'\n", packageName);
+			fmt::print(stderr, "Could not find path of package '{}'\n", packageName);
 			return 1;
 		}
 
 		fs::path path = findFile(package, fileName);
 		if(path.empty())
 		{
-			fprintf(stderr, "Could not find launch file '%s' in package '%s'\n",
+			fmt::print(stderr, "Could not find launch file '{}' in package '{}'\n",
 				fileName, packageName
 			);
 			return 1;
@@ -237,7 +239,7 @@ int main(int argc, char** argv)
 
 		if(!arg)
 		{
-			fprintf(stderr, "You specified a non-argument after an argument\n");
+			fmt::print(stderr, "You specified a non-argument after an argument\n");
 			return 1;
 		}
 
@@ -259,7 +261,7 @@ int main(int argc, char** argv)
 	}
 	catch(rosmon::launch::ParseException& e)
 	{
-		fprintf(stderr, "Could not load launch file: %s\n", e.what());
+		fmt::print(stderr, "Could not load launch file: {}\n", e.what());
 		return 1;
 	}
 
@@ -299,32 +301,32 @@ int main(int argc, char** argv)
 
 	// Check connectivity to ROS master
 	{
-		printf("ROS_MASTER_URI: '%s'\n", ros::master::getURI().c_str());
+		fmt::print("ROS_MASTER_URI: '{}'\n", ros::master::getURI());
 		if(ros::master::check())
 		{
-			printf("roscore is already running.\n");
+			fmt::print("roscore is already running.\n");
 		}
 		else
 		{
-			printf("Starting own roscore...\n");
-			fprintf(stderr, "Scratch that, I can't do that yet. Exiting...\n");
+			fmt::print("Starting own roscore...\n");
+			fmt::print(stderr, "Scratch that, I can't do that yet. Exiting...\n");
 			return 1;
 		}
 	}
 
 	ros::NodeHandle nh;
 
-	printf("Running as '%s'\n", ros::this_node::getName().c_str());
+	fmt::print("Running as '{}'\n", ros::this_node::getName());
 
 	rosmon::monitor::Monitor monitor(config, watcher);
 	monitor.logMessageSignal.connect(boost::bind(&rosmon::Logger::log, logger.get(), _1, _2));
 
-	printf("\n\n");
+	fmt::print("\n\n");
 	monitor.setParameters();
 
 	if(config->nodes().empty())
 	{
-		printf("No ROS nodes to be launched. Finished...\n");
+		fmt::print("No ROS nodes to be launched. Finished...\n");
 		return 0;
 	}
 
@@ -400,9 +402,10 @@ int main(int argc, char** argv)
 		{
 			if(node->coredumpAvailable())
 			{
-				std::stringstream ss;
-				ss << std::setw(20) << node->name() << ": # " + node->debuggerCommand();
-				ui->log("[rosmon]", ss.str());
+				ui->log(
+					"[rosmon]",
+					fmt::format("{:20}: # {}", node->name(), node->debuggerCommand())
+				);
 			}
 		}
 	}

--- a/src/monitor/linux_process_info.cpp
+++ b/src/monitor/linux_process_info.cpp
@@ -7,6 +7,8 @@
 #include <cstdio>
 #include <cstring>
 
+#include <fmt/format.h>
+
 namespace rosmon
 {
 namespace monitor
@@ -24,7 +26,7 @@ jiffies_t kernel_hz()
 		g_kernel_hz = sysconf(_SC_CLK_TCK);
 		if(g_kernel_hz == (jiffies_t)-1)
 		{
-			fprintf(stderr, "Warning: Could not obtain value of USER_HZ."
+			fmt::print(stderr, "Warning: Could not obtain value of USER_HZ."
 				"CPU load measurements might be inaccurate.\n"
 			);
 			g_kernel_hz = 100;
@@ -41,7 +43,7 @@ std::size_t page_size()
 		g_page_size = sysconf(_SC_PAGESIZE);
 		if(g_page_size == (std::size_t)-1)
 		{
-			fprintf(stderr, "Warning: Could not obtain page size.");
+			fmt::print(stderr, "Warning: Could not obtain page size.");
 			g_page_size = 4096;
 		}
 	}

--- a/src/monitor/monitor.cpp
+++ b/src/monitor/monitor.cpp
@@ -17,20 +17,14 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include <fmt/format.h>
+
 #include "linux_process_info.h"
 
-static std::runtime_error error(const char* fmt, ...)
+template<typename... Args>
+std::runtime_error error(const char* fmt, const Args& ... args)
 {
-	va_list args;
-	va_start(args, fmt);
-
-	char str[1024];
-
-	vsnprintf(str, sizeof(str), fmt, args);
-
-	va_end(args);
-
-	return std::runtime_error(str);
+	return std::runtime_error(fmt::format(fmt, args...));
 }
 
 namespace rosmon
@@ -80,7 +74,7 @@ void Monitor::setParameters()
 			{
 				std::string paramNamespace = node->namespaceString() + "/" + node->name() + "/";
 
-				log("Deleting parameters in namespace %s", paramNamespace.c_str());
+				log("Deleting parameters in namespace {}", paramNamespace.c_str());
 
 				if(paramNames.empty())
 				{
@@ -124,7 +118,7 @@ void Monitor::forceExit()
 	{
 		if(node->running())
 		{
-			log(" - %s\n", node->name().c_str());
+			log(" - {}\n", node->name());
 			node->forceExit();
 		}
 	}
@@ -144,22 +138,17 @@ bool Monitor::allShutdown()
 
 void Monitor::handleRequiredNodeExit(const std::string& name)
 {
-	log("Required node '%s' exited, shutting down...", name.c_str());
+	log("Required node '{}' exited, shutting down...", name);
 	m_ok = false;
 }
 
-void Monitor::log(const char* fmt, ...)
+template<typename... Args>
+void Monitor::log(const char* fmt, const Args& ... args)
 {
-	static char buf[512];
-
-	va_list v;
-	va_start(v, fmt);
-
-	vsnprintf(buf, sizeof(buf), fmt, v);
-
-	va_end(v);
-
-	logMessageSignal("[rosmon]", buf);
+	logMessageSignal(
+		"[rosmon]",
+		fmt::format(fmt, args...)
+	);
 }
 
 void Monitor::updateStats()

--- a/src/monitor/monitor.h
+++ b/src/monitor/monitor.h
@@ -51,7 +51,8 @@ private:
 		bool active;
 	};
 
-	void log(const char* fmt, ...) __attribute__((format (printf, 2, 3)));
+	template<typename... Args>
+	void log(const char* fmt, const Args& ... args);
 
 	void handleRequiredNodeExit(const std::string& name);
 

--- a/src/monitor/node_monitor.h
+++ b/src/monitor/node_monitor.h
@@ -179,7 +179,8 @@ private:
 
 	void communicate();
 
-	void log(const char* fmt, ...) __attribute__ (( format (printf, 2, 3) ));
+	template<typename... Args>
+	void log(const char* format, const Args& ... args);
 	void checkStop();
 	void gatherCoredump(int signal);
 

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -18,6 +18,8 @@
 #include <boost/regex.hpp>
 #include <boost/tokenizer.hpp>
 
+#include <fmt/format.h>
+
 namespace rosmon
 {
 
@@ -146,7 +148,7 @@ Terminal::Terminal()
 		}
 		else
 		{
-			fprintf(stderr, "Warning: Unknown ROSMON_COLOR_MODE value: '%s'\n", overrideMode);
+			fmt::print(stderr, "Warning: Unknown ROSMON_COLOR_MODE value: '{}'\n", overrideMode);
 		}
 	}
 	else
@@ -172,7 +174,7 @@ Terminal::Terminal()
 	int ret;
 	if(setupterm(termOverride, STDOUT_FILENO, &ret) != OK)
 	{
-		printf("Could not setup the terminal. Disabling all colors...\n");
+		fmt::print("Could not setup the terminal. Disabling all colors...\n");
 		return;
 	}
 
@@ -190,14 +192,14 @@ Terminal::Terminal()
 		if(bgColor && bgColor != (char*)-1)
 			m_bgColorStr = bgColor;
 		else
-			printf("Your terminal does not support ANSI background!\n");
+			fmt::print("Your terminal does not support ANSI background!\n");
 	}
 	{
 		const char* fgColor = tigetstr("setaf");
 		if(fgColor && fgColor != (char*)-1)
 			m_fgColorStr = fgColor;
 		else
-			printf("Your terminal does not support ANSI foreground!\n");
+			fmt::print("Your terminal does not support ANSI foreground!\n");
 	}
 
 	m_opStr = tigetstr("op");
@@ -393,13 +395,10 @@ void Terminal::setWindowTitle(const std::string& title)
 
 void Terminal::clearWindowTitle(const std::string& backup)
 {
-	char buf[256];
-
 	fputs("\033]30;%d : %n\007", stdout);
 
 	// screen/tmux style
-	snprintf(buf, sizeof(buf), "\033k%s\033\\", backup.c_str());
-	fputs(buf, stdout);
+	fmt::print("\033k{}\033\\", backup);
 }
 
 }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -7,6 +7,8 @@
 #include <cstdlib>
 #include <ros/node_handle.h>
 
+#include <fmt/format.h>
+
 static unsigned int g_statusLines = 2;
 static std::string g_windowTitle;
 
@@ -103,9 +105,9 @@ void UI::drawStatusLine()
 
 	// Print menu if a node is selected
 	if(m_selectedNode != -1)
-		printf("Actions: s: start, k: stop, d: debug");
+		fmt::print("Actions: s: start, k: stop, d: debug");
 
-	printf("\n");
+	fmt::print("\n");
 
 	int col = 0;
 
@@ -114,17 +116,6 @@ void UI::drawStatusLine()
 
 	for(auto& node : m_monitor->nodes())
 	{
-		char label[NODE_WIDTH+2];
-		auto nodeNameLen = static_cast<int>(node->name().length());
-		int padding = std::max<int>(0, (NODE_WIDTH - nodeNameLen)/2);
-
-		for(int i = 0; i < padding; ++i)
-			label[i] = ' ';
-		int c = snprintf(label+padding, NODE_WIDTH+1-padding, "%s", node->name().c_str());
-		for(int i = padding + c; i < NODE_WIDTH; ++i)
-			label[i] = ' ';
-		label[NODE_WIDTH] = 0;
-
 		// Print key with grey background
 		m_term.setSimpleForeground(Terminal::Black);
 
@@ -132,7 +123,7 @@ void UI::drawStatusLine()
 			m_term.setBackgroundColor(0xC8C8C8);
 		else
 			m_term.setSimpleBackground(Terminal::White);
-		printf("%c", key);
+		fmt::print("{:c}", key);
 
 		switch(node->state())
 		{
@@ -150,10 +141,11 @@ void UI::drawStatusLine()
 				break;
 		}
 
+		std::string label = node->name().substr(0, NODE_WIDTH);
 		if(i == m_selectedNode)
-			printf("[%s]", label);
+			fmt::print("[{:^{}}]", label, NODE_WIDTH);
 		else
-			printf(" %s ", label);
+			fmt::print(" {:^{}} ", label, NODE_WIDTH);
 		m_term.setStandardColors();
 
 		// Primitive wrapping control
@@ -214,7 +206,7 @@ void UI::log(const std::string& channel, const std::string& str)
 		m_term.setSimplePair(Terminal::Black, Terminal::White);
 	}
 
-	printf("%20s:", channel.c_str());
+	fmt::print("{:>20}:", channel);
 	m_term.setStandardColors();
 	m_term.clearToEndOfLine();
 	putchar(' ');

--- a/test/xml/test_arg.cpp
+++ b/test/xml/test_arg.cpp
@@ -63,7 +63,7 @@ TEST_CASE("arg unset", "[arg]")
 				<param name="test" value="$(arg arg1)" />
 			</launch>
 		)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 
 	REQUIRE_THROWS_AS(
@@ -73,6 +73,6 @@ TEST_CASE("arg unset", "[arg]")
 				<param name="test" value="$(arg arg1)" />
 			</launch>
 		)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 }

--- a/test/xml/test_basic.cpp
+++ b/test/xml/test_basic.cpp
@@ -26,7 +26,7 @@ TEST_CASE("basic: invalid XML", "[basic]")
 			<launch><abc>
 			</launch>
 		)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 }
 

--- a/test/xml/test_if_unless.cpp
+++ b/test/xml/test_if_unless.cpp
@@ -46,6 +46,6 @@ TEST_CASE("if/unless invalid", "[if_unless]")
 
 	REQUIRE_THROWS_AS(
 		LaunchConfig().parseString(R"EOF(<launch><param if="unknown_value" name="test" value="test" /></launch>)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 }

--- a/test/xml/test_node.cpp
+++ b/test/xml/test_node.cpp
@@ -115,7 +115,7 @@ TEST_CASE("node invalid", "[node]")
 				<node name="test_node" />
 			</launch>
 		)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 }
 

--- a/test/xml/test_param.cpp
+++ b/test/xml/test_param.cpp
@@ -100,7 +100,7 @@ TEST_CASE("param failing command", "[param]")
 	config.parseString(R"EOF(<launch><param name="test" command="false" /></launch>)EOF");
 	REQUIRE_THROWS_AS(
 		config.evaluateParameters(),
-		LaunchConfig::ParseException
+		ParseException
 	);
 }
 
@@ -188,22 +188,22 @@ TEST_CASE("wrong param types", "[param]")
 {
 	REQUIRE_THROWS_AS(
 		LaunchConfig().parseString(R"EOF(<launch><param name="test" value="abc" type="int" /></launch>)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 
 	REQUIRE_THROWS_AS(
 		LaunchConfig().parseString(R"EOF(<launch><param name="test" value="0.5" type="int" /></launch>)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 
 	REQUIRE_THROWS_AS(
 		LaunchConfig().parseString(R"EOF(<launch><param name="test" value="0.5" type="bool" /></launch>)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 
 	REQUIRE_THROWS_AS(
 		LaunchConfig().parseString(R"EOF(<launch><param name="test" value="invalid: {{ yaml}} here" type="yaml" /></launch>)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 
 	{
@@ -213,13 +213,13 @@ TEST_CASE("wrong param types", "[param]")
 
 		REQUIRE_THROWS_AS(
 			config.evaluateParameters(),
-			LaunchConfig::ParseException
+			ParseException
 		);
 	}
 
 	REQUIRE_THROWS_AS(
 		LaunchConfig().parseString(R"EOF(<launch><param name="test" value="0.5" type="unknown_type" /></launch>)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 }
 
@@ -227,17 +227,17 @@ TEST_CASE("invalid param input combinations", "[param]")
 {
 	REQUIRE_THROWS_AS(
 		LaunchConfig().parseString(R"EOF(<launch><param name="test" value="abc" command="echo -ne test" /></launch>)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 
 	REQUIRE_THROWS_AS(
 		LaunchConfig().parseString(R"EOF(<launch><param name="test" textfile="$(find rosmon)/test/textfile.txt" command="echo -ne test" /></launch>)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 
 	REQUIRE_THROWS_AS(
 		LaunchConfig().parseString(R"EOF(<launch><param name="test" /></launch>)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 }
 

--- a/test/xml/test_rosparam.cpp
+++ b/test/xml/test_rosparam.cpp
@@ -58,7 +58,7 @@ hello: {{ invalid }} test
 </rosparam>
 			</launch>
 		)EOF"),
-		LaunchConfig::ParseException
+		ParseException
 	);
 }
 

--- a/test/xml/test_subst.cpp
+++ b/test/xml/test_subst.cpp
@@ -41,7 +41,7 @@ TEST_CASE("env", "[subst]")
 					<param name="env_test" value="$(env ROSMON_UNLIKELY_TO_BE_SET)" />
 				</launch>
 			)EOF"),
-			LaunchConfig::ParseException
+			ParseException
 		);
 	}
 }
@@ -140,7 +140,7 @@ TEST_CASE("find", "[subst]")
 					<param name="test" value="$(find rosmon_this_package_is_unlikely_to_be_there)" />
 				</launch>
 			)EOF"),
-			LaunchConfig::ParseException
+			ParseException
 		);
 	}
 }
@@ -180,7 +180,7 @@ TEST_CASE("anon", "[subst]")
 					<node name="$(anon foo)" pkg="rospy_tutorials" type="talker.py" />
 				</launch>
 			)EOF"),
-			LaunchConfig::ParseException
+			ParseException
 		);
 	}
 }
@@ -211,7 +211,7 @@ TEST_CASE("arg", "[subst]")
 					<param name="test" value="$(arg test_arg_unknown)" />
 				</launch>
 			)EOF"),
-			LaunchConfig::ParseException
+			ParseException
 		);
 	}
 
@@ -305,7 +305,7 @@ TEST_CASE("eval", "[subst]")
 					<param name="test" value="$(eval acos)"/>
 				</launch>
 			)EOF"),
-			LaunchConfig::ParseException
+			ParseException
 		);
 	}
 }
@@ -339,7 +339,7 @@ TEST_CASE("subst invalid", "[subst]")
 					<param name="test" value="$(unknown_subst parameter)" />
 				</launch>
 			)EOF"),
-			LaunchConfig::ParseException
+			ParseException
 		);
 	}
 }


### PR DESCRIPTION
[fmt](http://fmtlib.net/) is a type-safe C++11 format string library. This PR replaces a lot of manual low-level formatting code with `fmt::format` calls. Issues like #19 should be less likely to occur.