### PR TITLE
Support <remap> in other scopes than <node>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ if(CATKIN_ENABLE_TESTING)
 		include_directories(${catch_ros_INCLUDE_DIRS})
 
 		catch_add_test(test_xml_loading
+			test/xml/node_utils.cpp
 			test/xml/test_arg.cpp
 			test/xml/test_env.cpp
 			test/xml/test_basic.cpp
@@ -209,6 +210,7 @@ if(CATKIN_ENABLE_TESTING)
 			test/xml/test_include.cpp
 			test/xml/test_node.cpp
 			test/xml/test_param.cpp
+			test/xml/test_remap.cpp
 			test/xml/test_rosparam.cpp
 			test/xml/test_subst.cpp
 		)

--- a/src/launch/launch_config.h
+++ b/src/launch/launch_config.h
@@ -111,6 +111,10 @@ public:
 	inline LaunchConfig* config()
 	{ return m_config; }
 
+	void setRemap(const std::string& from, const std::string& to);
+	const std::map<std::string, std::string>& remappings()
+	{ return m_remappings; }
+
 	template<typename... Args>
 	ParseException error(const char* fmt, const Args& ... args) const
 	{
@@ -135,6 +139,7 @@ private:
 	int m_currentLine = -1;
 	std::map<std::string, std::string> m_args;
 	std::map<std::string, std::string> m_environment;
+	std::map<std::string, std::string> m_remappings;
 };
 
 class LaunchConfig
@@ -178,6 +183,7 @@ private:
 	void parseInclude(TiXmlElement* element, ParseContext ctx);
 	void parseArgument(TiXmlElement* element, ParseContext& ctx);
 	void parseEnv(TiXmlElement* element, ParseContext& ctx);
+	void parseRemap(TiXmlElement* element, ParseContext& ctx);
 
 	void loadYAMLParams(const ParseContext& ctx, const YAML::Node& n, const std::string& prefix);
 

--- a/src/launch/node.cpp
+++ b/src/launch/node.cpp
@@ -42,9 +42,9 @@ Node::Node(std::string name, std::string package, std::string type)
 	m_executable = PackageRegistry::getExecutable(m_package, m_type);
 }
 
-void Node::addRemapping(const std::string& from, const std::string& to)
+void Node::setRemappings(const std::map<std::string, std::string>& remappings)
 {
-	m_remappings[from] = to;
+	m_remappings = remappings;
 }
 
 void Node::addExtraArguments(const std::string& argString)

--- a/src/launch/node.h
+++ b/src/launch/node.h
@@ -25,7 +25,7 @@ public:
 
 	Node(std::string name, std::string package, std::string type);
 
-	void addRemapping(const std::string& from, const std::string& to);
+	void setRemappings(const std::map<std::string, std::string>& remappings);
 	void addExtraArguments(const std::string& argString);
 	void setNamespace(const std::string& ns);
 	void setExtraEnvironment(const std::map<std::string, std::string>& env);

--- a/test/basic.launch
+++ b/test/basic.launch
@@ -46,4 +46,12 @@ yaml:
 		<param name="private_param1" value="hello_world" />
 		<param name="~private_param2" value="hello_world" />
 	</node>
+
+	<!-- Test global remapping -->
+	<remap from="original_test_input" to="remapped_test_input" />
+	<remap from="original_test_output" to="remapped_test_output" />
+	<node name="test2" pkg="rosmon" type="test_node.py">
+			<remap from="~input" to="/original_test_input" />
+			<remap from="~output" to="/original_test_output" />
+	</node>
 </launch>

--- a/test/xml/node_utils.cpp
+++ b/test/xml/node_utils.cpp
@@ -1,0 +1,43 @@
+// Test utils for nodes
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include "node_utils.h"
+
+#include <sstream>
+
+#include <catch_ros/catch.hpp>
+
+std::string printMapping(const std::map<std::string, std::string>& mapping)
+{
+	std::stringstream ss;
+	ss << "{ ";
+	for(auto& pair : mapping)
+	{
+		ss << "'" << pair.first << "':='" << pair.second << "', ";
+	}
+	ss << "}";
+
+	return ss.str();
+}
+
+rosmon::launch::Node::Ptr getNode(const std::vector<rosmon::launch::Node::Ptr>& nodes, const std::string& name, const std::string& namespaceString)
+{
+	rosmon::launch::Node::Ptr ret;
+
+	INFO("Looking for node '" << name << "' in namespace '" << namespaceString << "'");
+
+	for(auto& node : nodes)
+	{
+		if(node->namespaceString() != namespaceString)
+			continue;
+
+		if(node->name() == name)
+		{
+			REQUIRE(!ret);
+			ret = node;
+		}
+	}
+
+	REQUIRE(ret);
+	return ret;
+}

--- a/test/xml/node_utils.h
+++ b/test/xml/node_utils.h
@@ -1,0 +1,45 @@
+// Test utils for nodes
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#ifndef NODE_UTILS_H
+#define NODE_UTILS_H
+
+#include <catch_ros/catch.hpp>
+
+#include "../../src/launch/node.h"
+
+namespace Catch
+{
+	template<>
+	struct StringMaker<rosmon::launch::Node::Ptr>
+	{
+		static std::string convert(const rosmon::launch::Node::Ptr& node)
+		{
+			if(node)
+				return "NodePtr(name='" + node->name() + "', namespace='" + node->namespaceString() + "')";
+			else
+				return "NodePtr()";
+		}
+	};
+
+	template<>
+	struct StringMaker<std::vector<rosmon::launch::Node::Ptr>>
+	{
+		static std::string convert(const std::vector<rosmon::launch::Node::Ptr>& nodes)
+		{
+			std::stringstream ss;
+			ss << "{ ";
+			for(auto& n : nodes)
+				ss << StringMaker<rosmon::launch::Node::Ptr>::convert(n) << ", ";
+			ss << "}";
+
+			return ss.str();
+		}
+	};
+}
+
+std::string printMapping(const std::map<std::string, std::string>& mapping);
+
+rosmon::launch::Node::Ptr getNode(const std::vector<rosmon::launch::Node::Ptr>& nodes, const std::string& name, const std::string& namespaceString="");
+
+#endif

--- a/test/xml/test_node.cpp
+++ b/test/xml/test_node.cpp
@@ -7,74 +7,10 @@
 
 #include <boost/filesystem.hpp>
 
+#include "node_utils.h"
 #include "param_utils.h"
 
 using namespace rosmon::launch;
-
-namespace Catch
-{
-	template<>
-	struct StringMaker<Node::Ptr>
-	{
-		static std::string convert(const Node::Ptr& node)
-		{
-			if(node)
-				return "NodePtr(name='" + node->name() + "', namespace='" + node->namespaceString() + "')";
-			else
-				return "NodePtr()";
-		}
-	};
-
-	template<>
-	struct StringMaker<std::vector<Node::Ptr>>
-	{
-		static std::string convert(const std::vector<Node::Ptr>& nodes)
-		{
-			std::stringstream ss;
-			ss << "{ ";
-			for(auto& n : nodes)
-				ss << StringMaker<Node::Ptr>::convert(n) << ", ";
-			ss << "}";
-
-			return ss.str();
-		}
-	};
-}
-
-static std::string printMapping(const std::map<std::string, std::string>& mapping)
-{
-	std::stringstream ss;
-	ss << "{ ";
-	for(auto& pair : mapping)
-	{
-		ss << "'" << pair.first << "':='" << pair.second << "', ";
-	}
-	ss << "}";
-
-	return ss.str();
-}
-
-Node::Ptr getNode(const std::vector<Node::Ptr>& nodes, const std::string& name, const std::string& namespaceString="")
-{
-	Node::Ptr ret;
-
-	INFO("Looking for node '" << name << "' in namespace '" << namespaceString << "'");
-
-	for(auto& node : nodes)
-	{
-		if(node->namespaceString() != namespaceString)
-			continue;
-
-		if(node->name() == name)
-		{
-			REQUIRE(!ret);
-			ret = node;
-		}
-	}
-
-	REQUIRE(ret);
-	return ret;
-}
 
 TEST_CASE("node basic", "[node]")
 {

--- a/test/xml/test_remap.cpp
+++ b/test/xml/test_remap.cpp
@@ -1,0 +1,39 @@
+// Test <remap> tags
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include <catch_ros/catch.hpp>
+
+#include "../../src/launch/launch_config.h"
+
+#include "node_utils.h"
+
+using namespace rosmon::launch;
+
+TEST_CASE("remap", "[remap]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch rosmon-name="rosmon_uut">
+				<remap from="topic_a" to="topic_b" />
+
+				<node name="test" pkg="rosmon" type="abort">
+						<remap from="~local_a" to="/global_a" />
+						<remap from="local_b" to="/global_b" />
+				</node>
+
+				<remap from="topic_c" to="topic_d" />
+		</launch>
+	)EOF");
+
+	auto node = getNode(config.nodes(), "test");
+
+	CAPTURE(printMapping(node->remappings()));
+
+	auto maps = node->remappings();
+
+	CHECK(maps.at("topic_a") == "topic_b");
+	CHECK(maps.at("~local_a") == "/global_a");
+	CHECK(maps.at("local_b") == "/global_b");
+
+	CHECK(maps.find("topic_c") == maps.end());
+}

--- a/test/xml/test_remap.cpp
+++ b/test/xml/test_remap.cpp
@@ -37,3 +37,26 @@ TEST_CASE("remap", "[remap]")
 
 	CHECK(maps.find("topic_c") == maps.end());
 }
+
+TEST_CASE("remap scoped", "[remap]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch rosmon-name="rosmon_uut">
+				<group ns="namespace">
+					<remap from="topic_a" to="topic_b" />
+				</group>
+
+				<node name="test" pkg="rosmon" type="abort">
+				</node>
+		</launch>
+	)EOF");
+
+	auto node = getNode(config.nodes(), "test");
+
+	CAPTURE(printMapping(node->remappings()));
+
+	auto maps = node->remappings();
+
+	CHECK(maps.find("topic_a") == maps.end());
+}


### PR DESCRIPTION
Essentially, `<remap>` behaves like `<env>`, so treat it the same way.

This also adds unit tests and an integration test for global `<remap>`.