### PR TITLE
YAML quoted strings

### DIFF
--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -865,6 +865,12 @@ XmlRpc::XmlRpcValue LaunchConfig::yamlToXmlRpc(const ParseContext& ctx, const YA
 	if(n.Tag() == "!!bool")
 		return XmlRpc::XmlRpcValue(n.as<bool>());
 
+	// If we have a "non-specific" tag '!', this means that the YAML scalar
+	// is non-plain, i.e. of type seq, map, or str. Since seq and map are
+	// handled above, we assume str in this case.
+	if(n.Tag() == "!")
+		return XmlRpc::XmlRpcValue(n.as<std::string>());
+
 	// Otherwise, we simply have to try things one by one...
 	try { return XmlRpc::XmlRpcValue(n.as<bool>()); }
 	catch(YAML::Exception&) {}

--- a/test/xml/test_rosparam.cpp
+++ b/test/xml/test_rosparam.cpp
@@ -21,6 +21,7 @@ test_ns:
   param2: hello
   param3: 3
   param4: 10.0
+  param5: "3"
 </rosparam>
 		</launch>
 	)EOF");
@@ -34,6 +35,7 @@ test_ns:
 	checkTypedParam<std::string>(params, "/test_ns/param2", XmlRpc::XmlRpcValue::TypeString, "hello");
 	checkTypedParam<int>(params, "/test_ns/param3", XmlRpc::XmlRpcValue::TypeInt, 3);
 	checkTypedParam<double>(params, "/test_ns/param4", XmlRpc::XmlRpcValue::TypeDouble, 10.0);
+	checkTypedParam<std::string>(params, "/test_ns/param5", XmlRpc::XmlRpcValue::TypeString, "3");
 }
 
 TEST_CASE("rosparam empty", "[rosparam]")


### PR DESCRIPTION
Make sure that we create string parameters for quoted YAML scalars. This fixes #33.