### PR TITLE
More complete support for rosparam features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(rosmon_launch_config
 	src/launch/launch_config.cpp
 	src/launch/substitution.cpp
 	src/launch/substitution_python.cpp
+	src/launch/yaml_params.cpp
 	src/package_registry.cpp
 )
 target_link_libraries(rosmon_launch_config

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -859,12 +859,14 @@ XmlRpc::XmlRpcValue LaunchConfig::yamlToXmlRpc(const ParseContext& ctx, const YA
 	// figure out the data type...
 
 	// Check if a YAML tag is present
-	if(n.Tag() == "!!int")
+	if(n.Tag() == "tag:yaml.org,2002:int")
 		return XmlRpc::XmlRpcValue(n.as<int>());
-	if(n.Tag() == "!!float")
+	if(n.Tag() == "tag:yaml.org,2002:float")
 		return XmlRpc::XmlRpcValue(n.as<double>());
-	if(n.Tag() == "!!bool")
+	if(n.Tag() == "tag:yaml.org,2002:bool")
 		return XmlRpc::XmlRpcValue(n.as<bool>());
+	if(n.Tag() == "tag:yaml.org,2002:str")
+		return XmlRpc::XmlRpcValue(n.as<std::string>());
 
 	// rosparam supports !!degrees and !!radians...
 	if(n.Tag() == "!degrees")

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -3,7 +3,7 @@
 
 #include "launch_config.h"
 #include "substitution.h"
-#include "substitution_python.h"
+#include "yaml_params.h"
 
 #include <ros/package.h>
 #include <ros/names.h>
@@ -17,7 +17,6 @@
 
 #include <boost/regex.hpp>
 #include <boost/algorithm/string/trim.hpp>
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include <yaml-cpp/yaml.h>
@@ -802,160 +801,6 @@ void LaunchConfig::parseROSParam(TiXmlElement* element, ParseContext ctx)
 	}
 	else
 		throw ctx.error("Unsupported rosparam command '{}'", command);
-}
-
-
-class XmlRpcValueCreator : public XmlRpc::XmlRpcValue
-{
-public:
-	static XmlRpcValueCreator createArray(const std::vector<XmlRpcValue>& values)
-	{
-		XmlRpcValueCreator ret;
-		ret._type = TypeArray;
-		ret._value.asArray = new ValueArray(values);
-
-		return ret;
-	}
-
-	static XmlRpcValueCreator createStruct(const std::map<std::string, XmlRpcValue>& members)
-	{
-		XmlRpcValueCreator ret;
-		ret._type = TypeStruct;
-		ret._value.asStruct = new std::map<std::string, XmlRpcValue>(members);
-		return ret;
-	}
-};
-
-XmlRpc::XmlRpcValue LaunchConfig::yamlToXmlRpc(const ParseContext& ctx, const YAML::Node& n)
-{
-	if(n.Type() != YAML::NodeType::Scalar)
-	{
-		switch(n.Type())
-		{
-			case YAML::NodeType::Map:
-			{
-				std::map<std::string, XmlRpc::XmlRpcValue> members;
-				for(YAML::const_iterator it = n.begin(); it != n.end(); ++it)
-				{
-					members[it->first.as<std::string>()] = yamlToXmlRpc(ctx, it->second);
-				}
-				return XmlRpcValueCreator::createStruct(members);
-			}
-			case YAML::NodeType::Sequence:
-			{
-				std::vector<XmlRpc::XmlRpcValue> values;
-				for(YAML::const_iterator it = n.begin(); it != n.end(); ++it)
-				{
-					values.push_back(yamlToXmlRpc(ctx, *it));
-				}
-				return XmlRpcValueCreator::createArray(values);
-			}
-			default:
-				throw ctx.error("Invalid YAML node type");
-		}
-	}
-
-	// Scalars are tricky, as XmlRpcValue is strongly typed. So we need to
-	// figure out the data type...
-
-	// Check if a YAML tag is present
-	if(n.Tag() == "tag:yaml.org,2002:int")
-		return XmlRpc::XmlRpcValue(n.as<int>());
-	if(n.Tag() == "tag:yaml.org,2002:float")
-		return XmlRpc::XmlRpcValue(n.as<double>());
-	if(n.Tag() == "tag:yaml.org,2002:bool")
-		return XmlRpc::XmlRpcValue(n.as<bool>());
-	if(n.Tag() == "tag:yaml.org,2002:str")
-		return XmlRpc::XmlRpcValue(n.as<std::string>());
-	if(n.Tag() == "tag:yaml.org,2002:binary")
-	{
-		auto binary = n.as<YAML::Binary>();
-
-		// XmlRpc API is stupid here and expects a mutable void*, so to keep
-		// things clean we do a copy.
-		std::vector<unsigned char> copy(binary.data(), binary.data()+binary.size());
-
-		return XmlRpc::XmlRpcValue(copy.data(), copy.size());
-	}
-
-	// rosparam supports !!degrees and !!radians...
-	if(n.Tag() == "!degrees")
-	{
-		try
-		{
-			return XmlRpc::XmlRpcValue(evaluateROSParamPython(n.as<std::string>()) * M_PI / 180.0);
-		}
-		catch(SubstitutionException& e)
-		{
-			throw ctx.error("{}", e.what());
-		}
-	}
-	if(n.Tag() == "!radians")
-	{
-		try
-		{
-			return XmlRpc::XmlRpcValue(evaluateROSParamPython(n.as<std::string>()));
-		}
-		catch(SubstitutionException& e)
-		{
-			throw ctx.error("{}", e.what());
-		}
-	}
-
-	// If we have a "non-specific" tag '!', this means that the YAML scalar
-	// is non-plain, i.e. of type seq, map, or str. Since seq and map are
-	// handled above, we assume str in this case.
-	if(n.Tag() == "!")
-		return XmlRpc::XmlRpcValue(n.as<std::string>());
-
-	// Otherwise, we simply have to try things one by one...
-	try { return XmlRpc::XmlRpcValue(n.as<bool>()); }
-	catch(YAML::Exception&) {}
-
-	try { return XmlRpc::XmlRpcValue(n.as<int>()); }
-	catch(YAML::Exception&) {}
-
-	try { return XmlRpc::XmlRpcValue(n.as<double>()); }
-	catch(YAML::Exception&) {}
-
-	try
-	{
-		std::string str = n.as<std::string>();
-
-		// rosparam supports deg(...) and rad(...) expressions, so we have to
-		// parse them here.
-
-		if(boost::starts_with(str, "deg(") && boost::ends_with(str, ")"))
-		{
-			try
-			{
-				return XmlRpc::XmlRpcValue(
-					evaluateROSParamPython(str.substr(4, str.size() - 5)) * M_PI / 180.0
-				);
-			}
-			catch(SubstitutionException& e)
-			{
-				throw ctx.error("{}", e.what());
-			}
-		}
-
-		if(boost::starts_with(str, "rad(") && boost::ends_with(str, ")"))
-		{
-			try
-			{
-				return XmlRpc::XmlRpcValue(evaluateROSParamPython(str.substr(4, str.size() - 5)));
-			}
-			catch(SubstitutionException& e)
-			{
-				throw ctx.error("{}", e.what());
-			}
-		}
-
-		return XmlRpc::XmlRpcValue(str);
-	}
-	catch(YAML::Exception&) {}
-
-	throw ctx.error("Could not convert YAML value");
 }
 
 void LaunchConfig::loadYAMLParams(const ParseContext& ctx, const YAML::Node& n, const std::string& prefix)

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -867,6 +867,16 @@ XmlRpc::XmlRpcValue LaunchConfig::yamlToXmlRpc(const ParseContext& ctx, const YA
 		return XmlRpc::XmlRpcValue(n.as<bool>());
 	if(n.Tag() == "tag:yaml.org,2002:str")
 		return XmlRpc::XmlRpcValue(n.as<std::string>());
+	if(n.Tag() == "tag:yaml.org,2002:binary")
+	{
+		auto binary = n.as<YAML::Binary>();
+
+		// XmlRpc API is stupid here and expects a mutable void*, so to keep
+		// things clean we do a copy.
+		std::vector<unsigned char> copy(binary.data(), binary.data()+binary.size());
+
+		return XmlRpc::XmlRpcValue(copy.data(), copy.size());
+	}
 
 	// rosparam supports !!degrees and !!radians...
 	if(n.Tag() == "!degrees")

--- a/src/launch/launch_config.h
+++ b/src/launch/launch_config.h
@@ -188,7 +188,6 @@ private:
 	void loadYAMLParams(const ParseContext& ctx, const YAML::Node& n, const std::string& prefix);
 
 	XmlRpc::XmlRpcValue paramToXmlRpc(const ParseContext& ctx, const std::string& value, const std::string& type = "");
-	XmlRpc::XmlRpcValue yamlToXmlRpc(const ParseContext& ctx, const YAML::Node& n);
 
 	ParseContext m_rootContext;
 

--- a/src/launch/substitution_python.h
+++ b/src/launch/substitution_python.h
@@ -13,7 +13,11 @@ namespace launch
 
 class ParseContext;
 
+//! Evaluate a $(eval ...) python expression
 std::string evaluatePython(const std::string& input, ParseContext& context);
+
+//! Evaluate a deg(...) rosparam expression
+double evaluateROSParamPython(const std::string& input);
 
 }
 }

--- a/src/launch/yaml_params.cpp
+++ b/src/launch/yaml_params.cpp
@@ -1,0 +1,173 @@
+// Methods for converting YAML into XmlRpcValues for the parameter server
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include "yaml_params.h"
+#include "launch_config.h"
+#include "substitution.h"
+#include "substitution_python.h"
+
+#include <boost/algorithm/string/predicate.hpp>
+
+namespace rosmon
+{
+namespace launch
+{
+
+namespace
+{
+	class XmlRpcValueCreator : public XmlRpc::XmlRpcValue
+	{
+	public:
+		static XmlRpcValueCreator createArray(const std::vector<XmlRpcValue>& values)
+		{
+			XmlRpcValueCreator ret;
+			ret._type = TypeArray;
+			ret._value.asArray = new ValueArray(values);
+
+			return ret;
+		}
+
+		static XmlRpcValueCreator createStruct(const std::map<std::string, XmlRpcValue>& members)
+		{
+			XmlRpcValueCreator ret;
+			ret._type = TypeStruct;
+			ret._value.asStruct = new std::map<std::string, XmlRpcValue>(members);
+			return ret;
+		}
+	};
+}
+
+XmlRpc::XmlRpcValue yamlToXmlRpc(const ParseContext& ctx, const YAML::Node& n)
+{
+	if(n.Type() != YAML::NodeType::Scalar)
+	{
+		switch(n.Type())
+		{
+			case YAML::NodeType::Map:
+			{
+				std::map<std::string, XmlRpc::XmlRpcValue> members;
+				for(YAML::const_iterator it = n.begin(); it != n.end(); ++it)
+				{
+					members[it->first.as<std::string>()] = yamlToXmlRpc(ctx, it->second);
+				}
+				return XmlRpcValueCreator::createStruct(members);
+			}
+			case YAML::NodeType::Sequence:
+			{
+				std::vector<XmlRpc::XmlRpcValue> values;
+				for(YAML::const_iterator it = n.begin(); it != n.end(); ++it)
+				{
+					values.push_back(yamlToXmlRpc(ctx, *it));
+				}
+				return XmlRpcValueCreator::createArray(values);
+			}
+			default:
+				throw ctx.error("Invalid YAML node type");
+		}
+	}
+
+	// Scalars are tricky, as XmlRpcValue is strongly typed. So we need to
+	// figure out the data type...
+
+	// Check if a YAML tag is present
+	if(n.Tag() == "tag:yaml.org,2002:int")
+		return XmlRpc::XmlRpcValue(n.as<int>());
+	if(n.Tag() == "tag:yaml.org,2002:float")
+		return XmlRpc::XmlRpcValue(n.as<double>());
+	if(n.Tag() == "tag:yaml.org,2002:bool")
+		return XmlRpc::XmlRpcValue(n.as<bool>());
+	if(n.Tag() == "tag:yaml.org,2002:str")
+		return XmlRpc::XmlRpcValue(n.as<std::string>());
+	if(n.Tag() == "tag:yaml.org,2002:binary")
+	{
+		auto binary = n.as<YAML::Binary>();
+
+		// XmlRpc API is stupid here and expects a mutable void*, so to keep
+		// things clean we do a copy.
+		std::vector<unsigned char> copy(binary.data(), binary.data()+binary.size());
+
+		return XmlRpc::XmlRpcValue(copy.data(), copy.size());
+	}
+
+	// rosparam supports !!degrees and !!radians...
+	if(n.Tag() == "!degrees")
+	{
+		try
+		{
+			return XmlRpc::XmlRpcValue(evaluateROSParamPython(n.as<std::string>()) * M_PI / 180.0);
+		}
+		catch(SubstitutionException& e)
+		{
+			throw ctx.error("{}", e.what());
+		}
+	}
+	if(n.Tag() == "!radians")
+	{
+		try
+		{
+			return XmlRpc::XmlRpcValue(evaluateROSParamPython(n.as<std::string>()));
+		}
+		catch(SubstitutionException& e)
+		{
+			throw ctx.error("{}", e.what());
+		}
+	}
+
+	// If we have a "non-specific" tag '!', this means that the YAML scalar
+	// is non-plain, i.e. of type seq, map, or str. Since seq and map are
+	// handled above, we assume str in this case.
+	if(n.Tag() == "!")
+		return XmlRpc::XmlRpcValue(n.as<std::string>());
+
+	// Otherwise, we simply have to try things one by one...
+	try { return XmlRpc::XmlRpcValue(n.as<bool>()); }
+	catch(YAML::Exception&) {}
+
+	try { return XmlRpc::XmlRpcValue(n.as<int>()); }
+	catch(YAML::Exception&) {}
+
+	try { return XmlRpc::XmlRpcValue(n.as<double>()); }
+	catch(YAML::Exception&) {}
+
+	try
+	{
+		std::string str = n.as<std::string>();
+
+		// rosparam supports deg(...) and rad(...) expressions, so we have to
+		// parse them here.
+
+		if(boost::starts_with(str, "deg(") && boost::ends_with(str, ")"))
+		{
+			try
+			{
+				return XmlRpc::XmlRpcValue(
+					evaluateROSParamPython(str.substr(4, str.size() - 5)) * M_PI / 180.0
+				);
+			}
+			catch(SubstitutionException& e)
+			{
+				throw ctx.error("{}", e.what());
+			}
+		}
+
+		if(boost::starts_with(str, "rad(") && boost::ends_with(str, ")"))
+		{
+			try
+			{
+				return XmlRpc::XmlRpcValue(evaluateROSParamPython(str.substr(4, str.size() - 5)));
+			}
+			catch(SubstitutionException& e)
+			{
+				throw ctx.error("{}", e.what());
+			}
+		}
+
+		return XmlRpc::XmlRpcValue(str);
+	}
+	catch(YAML::Exception&) {}
+
+	throw ctx.error("Could not convert YAML value");
+}
+
+}
+}

--- a/src/launch/yaml_params.h
+++ b/src/launch/yaml_params.h
@@ -1,0 +1,22 @@
+// Methods for converting YAML into XmlRpcValues for the parameter server
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#ifndef ROSMON_LAUNCH_YAML_PARAMS_H
+#define ROSMON_LAUNCH_YAML_PARAMS_H
+
+#include <XmlRpc.h>
+#include <yaml-cpp/yaml.h>
+
+namespace rosmon
+{
+namespace launch
+{
+
+class ParseContext;
+
+XmlRpc::XmlRpcValue yamlToXmlRpc(const ParseContext& ctx, const YAML::Node& n);
+
+}
+}
+
+#endif

--- a/test/xml/param_utils.h
+++ b/test/xml/param_utils.h
@@ -99,7 +99,10 @@ void checkTypedParam(const ParameterMap& parameters, const std::string& name, Xm
 	XmlRpc::XmlRpcValue value = it->second;
 
 	REQUIRE(value.getType() == expectedType);
-	REQUIRE(static_cast<T>(value) == expected);
+
+	T typedValue = value;
+
+	REQUIRE(typedValue == expected);
 }
 
 template<class T>
@@ -113,7 +116,9 @@ T getTypedParam(const ParameterMap& parameters, const std::string& name)
 
 	XmlRpc::XmlRpcValue value = it->second;
 
-	return static_cast<T>(value);
+	T typedValue = value;
+
+	return typedValue;
 }
 
 template<class T>
@@ -128,7 +133,10 @@ T getTypedParam(const ParameterMap& parameters, const std::string& name, XmlRpc:
 	XmlRpc::XmlRpcValue value = it->second;
 
 	REQUIRE(value.getType() == expectedType);
-	return static_cast<T>(value);
+
+	T typedValue = value;
+
+	return typedValue;
 }
 
 #endif

--- a/test/xml/param_utils.h
+++ b/test/xml/param_utils.h
@@ -116,4 +116,19 @@ T getTypedParam(const ParameterMap& parameters, const std::string& name)
 	return static_cast<T>(value);
 }
 
+template<class T>
+T getTypedParam(const ParameterMap& parameters, const std::string& name, XmlRpc::XmlRpcValue::Type expectedType)
+{
+	CAPTURE(parameters);
+	CAPTURE(name);
+
+	auto it = parameters.find(name);
+	REQUIRE(it != parameters.end());
+
+	XmlRpc::XmlRpcValue value = it->second;
+
+	REQUIRE(value.getType() == expectedType);
+	return static_cast<T>(value);
+}
+
 #endif

--- a/test/xml/test_rosparam.cpp
+++ b/test/xml/test_rosparam.cpp
@@ -108,3 +108,37 @@ a: false
 
 	checkTypedParam<bool>(config.parameters(), "/namespace/a", XmlRpc::XmlRpcValue::TypeBoolean, false);
 }
+
+TEST_CASE("rosparam angle extensions", "[rosparam]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+<rosparam>
+test_ns:
+  param1: rad(2*pi)
+  param2: deg(180)
+  param3: !degrees 181.0
+  param4: !radians 3.14169
+</rosparam>
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	CAPTURE(config.parameters());
+
+	auto& params = config.parameters();
+
+	double param1 = getTypedParam<double>(params, "/test_ns/param1", XmlRpc::XmlRpcValue::TypeDouble);
+	CHECK(param1 == Approx(2.0 * M_PI));
+
+	double param2 = getTypedParam<double>(params, "/test_ns/param2", XmlRpc::XmlRpcValue::TypeDouble);
+	CHECK(param2 == Approx(180.0 * M_PI / 180.0));
+
+	double param3 = getTypedParam<double>(params, "/test_ns/param3", XmlRpc::XmlRpcValue::TypeDouble);
+	CHECK(param3 == Approx(181.0 * M_PI / 180.0));
+
+	double param4 = getTypedParam<double>(params, "/test_ns/param4", XmlRpc::XmlRpcValue::TypeDouble);
+	CHECK(param4 == Approx(3.14169));
+}

--- a/test/xml/test_rosparam.cpp
+++ b/test/xml/test_rosparam.cpp
@@ -118,6 +118,7 @@ TEST_CASE("rosparam explicit types", "[rosparam]")
 test_ns:
   param1: !!str 1
   param2: !!float 1
+  param3: !!binary "aGVsbG8K"
 </rosparam>
 		</launch>
 	)EOF");
@@ -129,6 +130,10 @@ test_ns:
 	auto& params = config.parameters();
 	checkTypedParam<std::string>(params, "/test_ns/param1", XmlRpc::XmlRpcValue::TypeString, "1");
 	checkTypedParam<double>(params, "/test_ns/param2", XmlRpc::XmlRpcValue::TypeDouble, 1.0);
+
+	auto binParam = getTypedParam<XmlRpc::XmlRpcValue::BinaryData>(params, "/test_ns/param3", XmlRpc::XmlRpcValue::TypeBase64);
+	XmlRpc::XmlRpcValue::BinaryData expected{'h', 'e', 'l', 'l', 'o', '\n'};
+	CHECK(binParam == expected);
 }
 
 TEST_CASE("rosparam angle extensions", "[rosparam]")

--- a/test/xml/test_rosparam.cpp
+++ b/test/xml/test_rosparam.cpp
@@ -109,6 +109,28 @@ a: false
 	checkTypedParam<bool>(config.parameters(), "/namespace/a", XmlRpc::XmlRpcValue::TypeBoolean, false);
 }
 
+TEST_CASE("rosparam explicit types", "[rosparam]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+<rosparam>
+test_ns:
+  param1: !!str 1
+  param2: !!float 1
+</rosparam>
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	CAPTURE(config.parameters());
+
+	auto& params = config.parameters();
+	checkTypedParam<std::string>(params, "/test_ns/param1", XmlRpc::XmlRpcValue::TypeString, "1");
+	checkTypedParam<double>(params, "/test_ns/param2", XmlRpc::XmlRpcValue::TypeDouble, 1.0);
+}
+
 TEST_CASE("rosparam angle extensions", "[rosparam]")
 {
 	LaunchConfig config;


### PR DESCRIPTION
[rosparam] supports some additional syntactic elements in its YAML input, such as degree/radian conversions. This PR adds support for:

 * `deg(...)` and `rad(...)` with arbitrary Python expressions inside
 * `!degrees` and `!radians` YAML tags
 * Support for the YAML `!!binary` tag (gets put into a Base64 XmlRpcValue)
 * Fixes support for `!!int`, `!!str`, `!!bool`, `!!float`.

Unit tests for all of these are also added.

[rosparam]: https://wiki.ros.org/rosparam