### PR TITLE
main: Add option for flushing the logfile

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -16,8 +16,8 @@
 namespace rosmon
 {
 
-Logger::Logger(const std::string& path)
- : m_file(nullptr)
+Logger::Logger(const std::string& path, bool flush)
+ : m_file(nullptr), flush(flush)
 {
 	m_file = fopen(path.c_str(), "we");
 	if(!m_file)
@@ -57,6 +57,8 @@ void Logger::log(const std::string& source, const std::string& msg)
 	);
 	fwrite(msg.c_str(), 1, len, m_file);
 	fputc('\n', m_file);
+	if (flush)
+		fflush(m_file);
 }
 
 }

--- a/src/logger.h
+++ b/src/logger.h
@@ -20,13 +20,14 @@ public:
 	 *
 	 * @param path Path to the output file
 	 **/
-	explicit Logger(const std::string& path);
+	explicit Logger(const std::string& path, bool flush=false);
 	~Logger();
 
 	//! Log message
 	void log(const std::string& source, const std::string& msg);
 private:
 	FILE* m_file;
+	bool flush;
 };
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,6 +61,7 @@ void usage()
 		"\n"
 		"Options:\n"
 		"  --disable-ui   Disable fancy terminal UI\n"
+		"  --flush        Flush logfile after writing an entry\n"
 		"  --help         This help screen\n"
 		"  --log=FILE     Write log file to FILE\n"
 		"  --name=NAME    Use NAME as ROS node name. By default, an anonymous\n"
@@ -95,6 +96,7 @@ void logToStdout(const std::string& channel, const std::string& str)
 static const struct option OPTIONS[] = {
 	{"disable-ui", no_argument, nullptr, 'd'},
 	{"benchmark", no_argument, nullptr, 'b'},
+	{"flush", no_argument, nullptr, 'f'},
 	{"help", no_argument, nullptr, 'h'},
 	{"list-args", no_argument, nullptr, 'L'},
 	{"log",  required_argument, nullptr, 'l'},
@@ -116,6 +118,7 @@ int main(int argc, char** argv)
 
 	Action action = ACTION_LAUNCH;
 	bool enableUI = true;
+	bool flush = false;
 
 	// Parse options
 	while(true)
@@ -145,6 +148,9 @@ int main(int argc, char** argv)
 				break;
 			case 'd':
 				enableUI = false;
+				break;
+			case 'f':
+				flush = true;
 				break;
 		}
 	}
@@ -225,7 +231,7 @@ int main(int argc, char** argv)
 			logFile = buf;
 		}
 
-		logger.reset(new rosmon::Logger(logFile));
+		logger.reset(new rosmon::Logger(logFile, flush));
 	}
 
 	rosmon::FDWatcher::Ptr watcher(new rosmon::FDWatcher);


### PR DESCRIPTION
Add --flush option that will flush the logfile after each entry.

In most cases you want your logfile to be synced with the output of the application. I think that most loggers do flush the output after each entry.
