### PR TITLE
Add option for controlling the shutdown timeout

### DIFF
--- a/src/launch/launch_config.h
+++ b/src/launch/launch_config.h
@@ -152,6 +152,8 @@ public:
 
 	void setArgument(const std::string& name, const std::string& value);
 
+	void setDefaultStopTimeout(double timeout);
+
 	void parse(const std::string& filename, bool onlyArguments = false);
 	void parseString(const std::string& input, bool onlyArguments = false);
 
@@ -212,6 +214,8 @@ private:
 	std::string m_rosmonNodeName;
 
 	std::string m_windowTitle;
+
+	double m_defaultStopTimeout;
 };
 
 }

--- a/src/launch/node.cpp
+++ b/src/launch/node.cpp
@@ -38,6 +38,7 @@ Node::Node(std::string name, std::string package, std::string type)
  , m_required(false)
  , m_coredumpsEnabled(true)
  , m_clearParams(false)
+ , m_stopTimeout(5.0)
 {
 	m_executable = PackageRegistry::getExecutable(m_package, m_type);
 }
@@ -135,6 +136,11 @@ void Node::setWorkingDirectory(const std::string& cwd)
 void Node::setClearParams(bool on)
 {
 	m_clearParams = on;
+}
+
+void Node::setStopTimeout(double timeout)
+{
+	m_stopTimeout = timeout;
 }
 
 }

--- a/src/launch/node.h
+++ b/src/launch/node.h
@@ -40,6 +40,8 @@ public:
 
 	void setClearParams(bool on);
 
+	void setStopTimeout(double timeout);
+
 	std::string name() const
 	{ return m_name; }
 
@@ -86,6 +88,9 @@ public:
 
 	bool clearParams() const
 	{ return m_clearParams; }
+
+	double stopTimeout() const
+	{ return m_stopTimeout; }
 private:
 	std::string m_name;
 	std::string m_package;
@@ -112,6 +117,8 @@ private:
 	std::string m_workingDirectory;
 
 	bool m_clearParams;
+
+	double m_stopTimeout;
 };
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include <ros/this_node.h>
 
 #include <boost/filesystem.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include <unistd.h>
 #include <getopt.h>
@@ -67,6 +68,9 @@ void usage()
 		"  --name=NAME    Use NAME as ROS node name. By default, an anonymous\n"
 		"                 name is chosen.\n"
 		"  --no-start     Don't automatically start the nodes in the beginning\n"
+		"  --stop-timeout=SECONDS\n"
+		"                 Kill a process if it is still running this long\n"
+		"                 after the initial signal is send.\n"
 		"\n"
 		"rosmon also obeys some environment variables:\n"
 		"  ROSMON_COLOR_MODE   Can be set to 'truecolor', '256colors', 'ansi'\n"
@@ -103,6 +107,7 @@ static const struct option OPTIONS[] = {
 	{"log",  required_argument, nullptr, 'l'},
 	{"name", required_argument, nullptr, 'n'},
 	{"no-start", no_argument, nullptr, 'S'},
+	{"stop-timeout", required_argument, nullptr, 's'},
 	{nullptr, 0, nullptr, 0}
 };
 
@@ -122,6 +127,7 @@ int main(int argc, char** argv)
 	bool enableUI = true;
 	bool flushLog = false;
 	bool startNodes = true;
+	double stopTimeout = 5.0;
 
 	// Parse options
 	while(true)
@@ -157,6 +163,22 @@ int main(int argc, char** argv)
 				break;
 			case 'S':
 				startNodes = false;
+			case 's':
+				try
+				{
+					stopTimeout = boost::lexical_cast<double>(optarg);
+				}
+				catch(boost::bad_lexical_cast&)
+				{
+					fmt::print(stderr, "Bad value for --stop-timeout argument: '{}'\n");
+					return 1;
+				}
+
+				if(stopTimeout < 0)
+				{
+					fmt::print(stderr, "Stop timeout cannot be negative\n");
+					return 1;
+				}
 				break;
 		}
 	}
@@ -243,6 +265,7 @@ int main(int argc, char** argv)
 	rosmon::FDWatcher::Ptr watcher(new rosmon::FDWatcher);
 
 	rosmon::launch::LaunchConfig::Ptr config(new rosmon::launch::LaunchConfig);
+	config->setDefaultStopTimeout(stopTimeout);
 
 	// Parse launch file arguments from command line
 	for(int i = firstArg; i < argc; ++i)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -380,7 +380,7 @@ int main(int argc, char** argv)
 
 	// Wait for graceful shutdown
 	ros::WallTime start = ros::WallTime::now();
-	while(!monitor.allShutdown() && ros::WallTime::now() - start < ros::WallDuration(5.0))
+	while(!monitor.allShutdown() && ros::WallTime::now() - start < ros::WallDuration(monitor.shutdownTimeout()))
 	{
 		watcher->wait(waitDuration);
 

--- a/src/monitor/monitor.cpp
+++ b/src/monitor/monitor.cpp
@@ -136,6 +136,17 @@ bool Monitor::allShutdown()
 	return allShutdown;
 }
 
+double Monitor::shutdownTimeout()
+{
+	double timeout = 0.0;
+	// Find the biggest timeout
+	for(auto& node : m_nodes)
+		if(node->stopTimeout() > timeout)
+			timeout = node->stopTimeout();
+	return timeout;
+}
+
+
 void Monitor::handleRequiredNodeExit(const std::string& name)
 {
 	log("Required node '{}' exited, shutting down...", name);

--- a/src/monitor/monitor.h
+++ b/src/monitor/monitor.h
@@ -32,6 +32,8 @@ public:
 	void forceExit();
 	bool allShutdown();
 
+	double shutdownTimeout();
+
 	inline bool ok() const
 	{ return m_ok; }
 

--- a/src/monitor/node_monitor.cpp
+++ b/src/monitor/node_monitor.cpp
@@ -52,7 +52,7 @@ NodeMonitor::NodeMonitor(launch::Node::ConstPtr launchNode, FDWatcher::Ptr fdWat
  , m_restarting(false)
 {
 	m_restartTimer = nh.createWallTimer(ros::WallDuration(1.0), boost::bind(&NodeMonitor::start, this), false, false);
-	m_stopCheckTimer = nh.createWallTimer(ros::WallDuration(5.0), boost::bind(&NodeMonitor::checkStop, this));
+	m_stopCheckTimer = nh.createWallTimer(ros::WallDuration(m_launchNode->stopTimeout()), boost::bind(&NodeMonitor::checkStop, this));
 
 	m_processWorkingDirectory = m_launchNode->workingDirectory();
 

--- a/src/monitor/node_monitor.h
+++ b/src/monitor/node_monitor.h
@@ -158,6 +158,10 @@ public:
 	inline int pid() const
 	{ return m_pid; }
 
+	//! Node stop timeout
+	inline double stopTimeout() const
+	{ return m_launchNode->stopTimeout(); }
+
 	/**
 	 * @brief Logging signal
 	 *


### PR DESCRIPTION
This patch introduces the --shutdown-timeout option that gives the user
the ability to specify the time to wait for the nodes to shutdown after
the initial termination signal is sent.