### PR TITLE
gui: Fix index bug in showContextMenu

### DIFF
--- a/src/gui/mon_gui.cpp
+++ b/src/gui/mon_gui.cpp
@@ -147,7 +147,7 @@ void MonGUI::showContextMenu(const QPoint& point)
 	if(triggered)
 	{
 		rosmon::StartStop srv;
-		srv.request.node = m_model->nodeName(index.row()).toStdString();
+		srv.request.node = index.sibling(index.row(), NodeModel::COL_NAME).data().toString().toStdString();
 		srv.request.action = triggered->property("action").toInt();
 
 		if(!ros::service::call(m_model->namespaceString().toStdString() + "/start_stop", srv))

--- a/src/gui/node_model.cpp
+++ b/src/gui/node_model.cpp
@@ -202,13 +202,5 @@ QVariant NodeModel::headerData(int section, Qt::Orientation orientation, int rol
 	return QVariant();
 }
 
-QString NodeModel::nodeName(int row) const
-{
-	if(row < 0 || row > (int)m_entries.size())
-		return QString();
-
-	return m_entries[row].name;
-}
-
 }
 

--- a/src/gui/node_model.h
+++ b/src/gui/node_model.h
@@ -40,7 +40,6 @@ public:
 	inline QString namespaceString() const
 	{ return m_namespace; }
 
-	QString nodeName(int row) const;
 public Q_SLOTS:
 	void setNamespace(const QString& ns);
 	void unsubscribe();


### PR DESCRIPTION
Fix a bug that could lead to performing start/stop actions on wrong nodes.
This happened because the index used to determine the node those actions
should be performed on was the one returned by the view, which is the
index of the proxy model. This may be different than the one of the real
model.

You can replicate this bug if you use the rosmon plugin on an instance with multiple nodes. If you change the sorting by clicking on the header of a column and then try to perform a start/stop action on a node whose entry in the table got moved, you'll see that the action gets performed on a wrong node.