### PR TITLE
Feature/leading slash params

### DIFF
--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -460,16 +460,17 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx, ParamCont
 	// <node> tag - god only knows why.
 	if(fullName[0] != '/' || paramContext == PARAM_IN_NODE)
 	{
-		// We silently ignore "~" at the beginning of the name
-		if(fullName[0] == '~')
-			fullName = fullName.substr(1);
-
-		if(fullName.empty())
-			throw ctx.error("param name is empty");
-
 		// Same with "/" (see above)
-		if(fullName[0] == '/')
+		if(paramContext == PARAM_IN_NODE && fullName[0] == '/')
+		{
+			ctx.warning("leading slashes in <param> names are ignored inside <node> contexts for roslaunch compatibility.");
 			fullName = fullName.substr(1);
+		}
+		else if(fullName[0] == '~')
+		{
+			// We silently ignore "~" at the beginning of the name
+			fullName = fullName.substr(1);
+		}
 
 		fullName = ctx.prefix() + fullName;
 	}

--- a/src/launch/launch_config.h
+++ b/src/launch/launch_config.h
@@ -131,6 +131,21 @@ public:
 			return ParseException(fmt::format("{}: {}", m_filename, msg));
 		}
 	}
+
+	template<typename... Args>
+	void warning(const char* fmt, const Args& ... args) const
+	{
+		std::string msg = fmt::format(fmt, args...);
+
+		if(m_currentLine >= 0)
+		{
+			fmt::print(stderr, "{}:{}: Warning: {}\n", m_filename, m_currentLine, msg);
+		}
+		else
+		{
+			fmt::print(stderr, "{}: Warning: {}\n", m_filename, msg);
+		}
+	}
 private:
 	LaunchConfig* m_config;
 

--- a/src/launch/launch_config.h
+++ b/src/launch/launch_config.h
@@ -174,11 +174,17 @@ public:
 	std::string windowTitle() const
 	{ return m_windowTitle; }
 private:
+	enum ParamContext
+	{
+		PARAM_GENERAL, //!< <param> tag inside <node>
+		PARAM_IN_NODE, //!< <param> tag everywhere else
+	};
+
 	void parseTopLevelAttributes(TiXmlElement* element);
 
 	void parse(TiXmlElement* element, ParseContext* ctx, bool onlyArguments = false);
 	void parseNode(TiXmlElement* element, ParseContext ctx);
-	void parseParam(TiXmlElement* element, ParseContext ctx);
+	void parseParam(TiXmlElement* element, ParseContext ctx, ParamContext paramContext = PARAM_GENERAL);
 	void parseROSParam(TiXmlElement* element, ParseContext ctx);
 	void parseInclude(TiXmlElement* element, ParseContext ctx);
 	void parseArgument(TiXmlElement* element, ParseContext& ctx);

--- a/test/xml/test_param.cpp
+++ b/test/xml/test_param.cpp
@@ -166,6 +166,7 @@ TEST_CASE("scoped params", "[param]")
 			<node name="test_node" pkg="rosmon" type="abort">
 				<param name="private" value="val3" />
 				<param name="~private2" value="val4" />
+				<param name="/leading_slash" value="val5" />
 			</node>
 		</launch>
 	)EOF");
@@ -182,6 +183,8 @@ TEST_CASE("scoped params", "[param]")
 
 	checkTypedParam<std::string>(params, "/test_node/private", XmlRpc::XmlRpcValue::TypeString, "val3");
 	checkTypedParam<std::string>(params, "/test_node/private2", XmlRpc::XmlRpcValue::TypeString, "val4");
+
+	checkTypedParam<std::string>(params, "/test_node/leading_slash", XmlRpc::XmlRpcValue::TypeString, "val5");
 }
 
 TEST_CASE("wrong param types", "[param]")


### PR DESCRIPTION
Discovered that roslaunch ignores leading slashes in `<param>` tags - but only when inside a node!

```
<launch>
        <param name="~private" value="test" />

        <group ns="group_ns">
                <param name="relative" value="test" />
                <param name="/group_ns_absolute" value="test" />
        </group>

        <node name="joy" pkg="joy" type="joy_node">
                <param name="relative" value="test" />
                <param name="/joy_absolute" value="test" />
        </node>
</launch>
```

Here, roslaunch will create `/group_ns_absolute` but `/joy/joy_absolute` - go figure.

This PR creates a unit test assertion for that case and creates a special in-node mode for parsing params.