### PR TITLE
 launch_config: respect ROS_NAMESPACE variable

### DIFF
--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -170,6 +170,13 @@ LaunchConfig::LaunchConfig()
  , m_anonGen(std::random_device()())
  , m_defaultStopTimeout(5.0)
 {
+	const char* ROS_NAMESPACE = getenv("ROS_NAMESPACE");
+	if(ROS_NAMESPACE)
+	{
+		// Someone set ROS_NAMESPACE, we should respect it.
+		// This may happen in nested situations, e.g. rosmon launching rosmon.
+		m_rootContext = m_rootContext.enterScope(ROS_NAMESPACE);
+	}
 }
 
 void LaunchConfig::setArgument(const std::string& name, const std::string& value)

--- a/test/basic.launch
+++ b/test/basic.launch
@@ -54,4 +54,9 @@ yaml:
 			<remap from="~input" to="/original_test_input" />
 			<remap from="~output" to="/original_test_output" />
 	</node>
+
+	<!-- Nested rosmon instance (see #46) -->
+	<group ns="nested">
+		<node name="nested_mon" pkg="rosmon" type="rosmon" args="--disable-ui $(find rosmon)/test/nested.launch" />
+	</group>
 </launch>

--- a/test/basic.py
+++ b/test/basic.py
@@ -46,7 +46,7 @@ class BasicTest(unittest.TestCase):
 		except rospy.ROSException:
 			self.fail('Did not get state msg on /rosmon_uut/state' + repr(rospy.client.get_published_topics()))
 
-		self.assertEqual(len(state.nodes), 2)
+		self.assertEqual(len(state.nodes), 3)
 
 		test1 = [ n for n in state.nodes if n.name == 'test1' ]
 		self.assertEqual(len(test1), 1)
@@ -129,8 +129,13 @@ class BasicTest(unittest.TestCase):
 		sub.unregister()
 		pub.unregister()
 
+	def test_nested(self):
+		self.assertEqual(rospy.get_param("/nested/nested_param"), "hello")
+
 if __name__ == '__main__':
 	rospy.init_node('basic_test')
 
 	import rostest
 	rostest.rosrun('rosmon', 'basic', BasicTest)
+
+	time.sleep(1)

--- a/test/nested.launch
+++ b/test/nested.launch
@@ -1,0 +1,3 @@
+<launch>
+	<param name="nested_param" value="hello" />
+</launch>


### PR DESCRIPTION
This allows nested configurations like the one mentioned in #46.