### PR TITLE
Clean namespace names properly

### DIFF
--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -86,6 +86,14 @@ static bool isOnlyWhitespace(const std::string& input)
 	return true;
 }
 
+ParseContext ParseContext::enterScope(const std::string& prefix)
+{
+	ParseContext ret = *this;
+	ret.m_prefix = ros::names::clean(ret.m_prefix + prefix) + "/";
+
+	return ret;
+}
+
 std::string ParseContext::evaluate(const std::string& tpl, bool simplifyWhitespace)
 {
 	std::string simplified;

--- a/src/launch/launch_config.h
+++ b/src/launch/launch_config.h
@@ -77,15 +77,7 @@ public:
 			m_currentLine = -1;
 	}
 
-	ParseContext enterScope(const std::string& prefix)
-	{
-		ParseContext ret = *this;
-		ret.m_prefix = ret.m_prefix + prefix;
-		if(prefix[prefix.size()-1] != '/')
-			ret.m_prefix.push_back('/');
-
-		return ret;
-	}
+	ParseContext enterScope(const std::string& prefix);
 
 	std::string evaluate(const std::string& tpl, bool simplifyWhitespace = true);
 

--- a/test/xml/test_param.cpp
+++ b/test/xml/test_param.cpp
@@ -187,6 +187,29 @@ TEST_CASE("scoped params", "[param]")
 	checkTypedParam<std::string>(params, "/test_node/leading_slash", XmlRpc::XmlRpcValue::TypeString, "val5");
 }
 
+TEST_CASE("scoped params with double slash (#49)", "[param]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<group ns="/">
+				<param name="param1" value="hello" />
+			</group>
+
+			<node name="test_node" pkg="rosmon" type="abort" ns="/racecar">
+				<param name="private_param" value="hello again" />
+			</node>
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto& params = config.parameters();
+
+	checkTypedParam<std::string>(params, "/param1", XmlRpc::XmlRpcValue::TypeString, "hello");
+	checkTypedParam<std::string>(params, "/racecar/test_node/private_param", XmlRpc::XmlRpcValue::TypeString, "hello again");
+}
+
 TEST_CASE("wrong param types", "[param]")
 {
 	REQUIRE_THROWS_AS(


### PR DESCRIPTION
We now use `ros::names::clean()` for manipulation (concatenation) of ROS namespace names.
This fixes problems with double slashes as reported in #49.