### PR TITLE
launch: allow <arg default="XY"> in <include> tags

### DIFF
--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -926,6 +926,23 @@ void LaunchConfig::parseInclude(TiXmlElement* element, ParseContext ctx)
 		{
 			const char* name = e->Attribute("name");
 			const char* value = e->Attribute("value");
+			const char* defaultValue = e->Attribute("default");
+
+			if(!name)
+				throw ctx.error("<arg> inside include needs a name attribute");
+
+			if(!value && defaultValue)
+			{
+				// roslaunch allows this - god knows why.
+				ctx.warning(
+					"You are using <arg> inside an <include> tag with the "
+					"default=XY attribute - which is superfluous. "
+					"Use value=XY instead for less confusion. "
+					"Attribute name: {}",
+					name
+				);
+				value = defaultValue;
+			}
 
 			if(!name || !value)
 				throw ctx.error("<arg> inside include needs name and value");

--- a/test/xml/test_include.cpp
+++ b/test/xml/test_include.cpp
@@ -29,6 +29,29 @@ TEST_CASE("include basic", "[include]")
 	CHECK(getTypedParam<std::string>(params, "/test_argument") == "hello");
 }
 
+TEST_CASE("include default", "[include]")
+{
+	// roslaunch allows this - to me it seems quite confusing, since the value
+	// of the arg tag cannot be overriden, despite using "default".
+
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<arg name="test_argument" value="hello" />
+
+			<include file="$(find rosmon)/test/basic_sub.launch">
+				<arg name="test_argument" default="$(arg test_argument)" />
+			</include>
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto params = config.parameters();
+
+	CHECK(getTypedParam<std::string>(params, "/test_argument") == "hello");
+}
+
 TEST_CASE("include pass_all", "[include]")
 {
 	LaunchConfig config;


### PR DESCRIPTION
roslaunch allows this, so we should as well. Since it seems a bit
confusing, we issue a warning when this happens.
In these cases, `<arg value="XY">` should be applicable and is much clearer.

This also includes a unit test in `test/xml/include`.