### PR TITLE
Add ROSCONSOLE_STDOUT_LINE_BUFFERED support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,7 @@
 namespace fs = boost::filesystem;
 
 bool g_shouldStop = false;
+bool g_force_stdout_line_buffered = false;
 
 static fs::path findFile(const fs::path& base, const std::string& name)
 {
@@ -95,6 +96,11 @@ void logToStdout(const std::string& channel, const std::string& str)
 	clean.resize(len);
 
 	fmt::print("{:>20}: {}\n", channel, clean);
+
+	if(g_force_stdout_line_buffered)
+	{
+		std::cout << std::flush;
+	}
 }
 
 // Options
@@ -383,6 +389,15 @@ int main(int argc, char** argv)
 	else
 	{
 		monitor.logMessageSignal.connect(logToStdout);
+	}
+
+	char* line_buffered_env_var = getenv("ROSCONSOLE_STDOUT_LINE_BUFFERED");
+	if(line_buffered_env_var)
+	{
+		if(std::string(line_buffered_env_var) == "1")
+		{
+			g_force_stdout_line_buffered = true;
+		}
 	}
 
 	// ROS interface


### PR DESCRIPTION
Force a flush to stdout after each log line.

Based on rosconsole: https://github.com/ros/rosconsole/commit/71905d78

This is needed when `stdout` is used by a log system like the systemd journal or docker logs.

If a flush is not explicitly sent, the logs are buffered and only printed on first `stderr`, at shutdown or never.

To workaround that issue, I know that I can use `stdbuff -o L` before calling `rosmon` but it is less convenient.

Feel free to arrange the code if you prefer another implementation or use a command line argument instead of the environment variable because here, we use a `rosconsole` env var to alter `rosmon` behavior, maybe it is not the cleaner solution. But in my case, it allows me to not change my launch files.

I did not enabled this behavior by default because flushing on every line could alter performances ([like using `std::endl` everywhere](https://www.youtube.com/watch?v=GMqQOEZYVJQ)).