### PR TITLE
Fix file error checks

### DIFF
--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -567,7 +567,7 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx, ParamCont
 		m_paramJobs[fullName] = std::async(std::launch::deferred,
 			[=]() -> XmlRpc::XmlRpcValue {
 				std::ifstream stream(fullFile, std::ios::binary | std::ios::ate);
-				if(stream.bad())
+				if(!stream || stream.bad())
 					throw ctx.error("Could not open file '{}'", fullFile);
 
 				std::vector<char> data(stream.tellg(), 0);
@@ -689,7 +689,7 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx, ParamCont
 		*computeString = std::async(std::launch::deferred,
 			[=]() -> std::string {
 				std::ifstream stream(fullFile);
-				if(stream.bad())
+				if(!stream || stream.bad())
 					throw ctx.error("Could not open file '{}'", fullFile);
 
 				std::stringstream buffer;
@@ -791,7 +791,7 @@ void LaunchConfig::parseROSParam(TiXmlElement* element, ParseContext ctx)
 		{
 			fullFile = ctx.evaluate(file);
 			std::ifstream stream(fullFile);
-			if(stream.bad())
+			if(!stream || stream.bad())
 				throw ctx.error("Could not open file '{}'", fullFile);
 
 			std::stringstream buffer;

--- a/src/launch/launch_config.cpp
+++ b/src/launch/launch_config.cpp
@@ -567,7 +567,7 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx, ParamCont
 		m_paramJobs[fullName] = std::async(std::launch::deferred,
 			[=]() -> XmlRpc::XmlRpcValue {
 				std::ifstream stream(fullFile, std::ios::binary | std::ios::ate);
-				if(!stream || stream.bad())
+				if(!stream)
 					throw ctx.error("Could not open file '{}'", fullFile);
 
 				std::vector<char> data(stream.tellg(), 0);
@@ -689,7 +689,7 @@ void LaunchConfig::parseParam(TiXmlElement* element, ParseContext ctx, ParamCont
 		*computeString = std::async(std::launch::deferred,
 			[=]() -> std::string {
 				std::ifstream stream(fullFile);
-				if(!stream || stream.bad())
+				if(!stream)
 					throw ctx.error("Could not open file '{}'", fullFile);
 
 				std::stringstream buffer;
@@ -791,7 +791,7 @@ void LaunchConfig::parseROSParam(TiXmlElement* element, ParseContext ctx)
 		{
 			fullFile = ctx.evaluate(file);
 			std::ifstream stream(fullFile);
-			if(!stream || stream.bad())
+			if(!stream)
 				throw ctx.error("Could not open file '{}'", fullFile);
 
 			std::stringstream buffer;

--- a/test/xml/test_param.cpp
+++ b/test/xml/test_param.cpp
@@ -120,6 +120,23 @@ TEST_CASE("param textfile", "[param]")
 	checkTypedParam<std::string>(params, "/test", XmlRpc::XmlRpcValue::TypeString, "hello_world");
 }
 
+TEST_CASE("param textfile does not exist", "[param]")
+{
+	using Catch::Matchers::Contains;
+
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<param name="test" textfile="$(find rosmon)/test/textfile_does_not_exist.txt" />
+		</launch>
+	)EOF");
+
+	REQUIRE_THROWS_WITH(
+		config.evaluateParameters(),
+		Contains("file")
+	);
+}
+
 TEST_CASE("param binfile", "[param]")
 {
 	LaunchConfig config;


### PR DESCRIPTION
As noticed by Arturo in #66, we do not check for file errors correctly. We now check for
`!stream`, which checks for both `bad` and `fail` conditions.

Reference: http://www.cplusplus.com/reference/ios/ios/operator_not/

This also adds a corresponding unit test for the textfile case.