### PR TITLE
Feature: Added filtering ability to ncurses ui for node output streams

### DIFF
--- a/rosmon_core/src/terminal.h
+++ b/rosmon_core/src/terminal.h
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <string>
+#include <map>
 
 namespace rosmon
 {
@@ -158,6 +159,16 @@ public:
 	void setWindowTitle(const std::string& title);
 	void clearWindowTitle(const std::string& backup);
 
+
+	enum SpecialKey
+	{
+		SK_F1 = 0x100, SK_F2, SK_F3, SK_F4,
+		SK_F5, SK_F6, SK_F7, SK_F8,
+		SK_F9, SK_F10, SK_F11, SK_F12
+	};
+
+	int readKey();
+
 private:
 	bool m_valid;
 	bool m_256colors;
@@ -170,6 +181,10 @@ private:
 	std::string m_elStr;
 	std::string m_upStr;
 	std::string m_boldStr;
+
+	std::map<std::string, SpecialKey> m_specialKeys;
+
+	std::string m_currentEscapeStr;
 };
 
 }

--- a/rosmon_core/src/ui.cpp
+++ b/rosmon_core/src/ui.cpp
@@ -70,7 +70,6 @@ UI::~UI()
 	m_fdWatcher->removeFD(STDIN_FILENO);
 }
 
-
 void UI::setupColors()
 {
 	// Sample colors from the HUSL space
@@ -114,12 +113,12 @@ void UI::drawStatusLine()
 	}
 	else
 	{
-		fmt::print("Mute all: -, Unmute all: + ");
+		fmt::print("Global shortcuts: <node key>: show node menu, F9: mute all, F10: unmute all ");
 		if (anyMuted())
 		{
-			m_term.setSimpleForeground(Terminal::Yellow);
-			m_term.setSimpleBackground(Terminal::Black);
-			fmt::print("! Caution: nodes are being muted");
+			m_term.setSimpleForeground(Terminal::Black);
+			m_term.setSimpleBackground(Terminal::Yellow);
+			fmt::print("! Caution: Nodes muted !");
 			m_term.setStandardColors();
 		}
 	}
@@ -133,7 +132,7 @@ void UI::drawStatusLine()
 
 	for(auto& node : m_monitor->nodes())
 	{
-		// Print key with grey background	
+		// Print key with grey background
 		Terminal::SimpleColor keyForegroundColor = Terminal::Black;
 		Terminal::SimpleColor keyBackgroundColor = Terminal::White;
 		uint32_t keyBackgroundColor256 = 0xC8C8C8;
@@ -287,8 +286,8 @@ void UI::checkWindowSize()
 
 void UI::handleInput()
 {
-	char c;
-	if(read(STDIN_FILENO, &c, 1) != 1)
+	int c = m_term.readKey();
+	if(c < 0)
 		return;
 
 	if(m_selectedNode == -1)
@@ -297,12 +296,12 @@ void UI::handleInput()
 
 		// Check for Mute all keys first
 
-		if(c == '_' || c == '-')
+		if(c == Terminal::SK_F9)
 		{
 			muteAll();
 			return;
 		}
-		if(c == '=' || c == '+')
+		if(c == Terminal::SK_F10)
 		{
 			unmuteAll();
 			return;

--- a/rosmon_core/src/ui.cpp
+++ b/rosmon_core/src/ui.cpp
@@ -108,22 +108,20 @@ void UI::drawStatusLine()
 	if(m_selectedNode != -1)
 	{
 		auto& selectedNode = m_monitor->nodes()[m_selectedNode];
-		std::string muteOption;
-
-		if(isMuted(selectedNode->name()))
-		{
-			muteOption = "u: unmute";
-		}
-		else
-		{
-			muteOption = "m: mute";
-		}
+		std::string muteOption = isMuted(selectedNode->name()) ? "u: unmute" : "m: mute"; 
 
 		fmt::print("Actions: s: start, k: stop, d: debug, {}", muteOption);
 	}
 	else
 	{
-		fmt::print("Mute all: -, Unmute all: +");
+		fmt::print("Mute all: -, Unmute all: + ");
+		if (anyMuted())
+		{
+			m_term.setSimpleForeground(Terminal::Yellow);
+			m_term.setSimpleBackground(Terminal::Black);
+			fmt::print("! Caution: nodes are being muted");
+			m_term.setStandardColors();
+		}
 	}
 
 	fmt::print("\n");

--- a/rosmon_core/src/ui.cpp
+++ b/rosmon_core/src/ui.cpp
@@ -70,17 +70,6 @@ UI::~UI()
 	m_fdWatcher->removeFD(STDIN_FILENO);
 }
 
-void UI::toggleMute(const std::string &nodeName)
-{
-	if (isMuted(nodeName))
-	{
-		m_mutedSet.erase(nodeName);
-	}
-	else
-	{
-		m_mutedSet.insert(nodeName);
-	}
-}
 
 void UI::setupColors()
 {
@@ -123,7 +112,7 @@ void UI::drawStatusLine()
 
 		if(isMuted(selectedNode->name()))
 		{
-			muteOption = "m: unmute";
+			muteOption = "u: unmute";
 		}
 		else
 		{
@@ -131,6 +120,10 @@ void UI::drawStatusLine()
 		}
 
 		fmt::print("Actions: s: start, k: stop, d: debug, {}", muteOption);
+	}
+	else
+	{
+		fmt::print("Mute all: -, Unmute all: +");
 	}
 
 	fmt::print("\n");
@@ -304,6 +297,19 @@ void UI::handleInput()
 	{
 		int nodeIndex = -1;
 
+		// Check for Mute all keys first
+
+		if(c == '_' || c == '-')
+		{
+			muteAll();
+			return;
+		}
+		if(c == '=' || c == '+')
+		{
+			unmuteAll();
+			return;
+		}
+
 		if(c >= 'a' && c <= 'z')
 			nodeIndex = c - 'a';
 		else if(c >= 'A' && c <= 'Z')
@@ -332,7 +338,10 @@ void UI::handleInput()
 				node->launchDebugger();
 				break;
 			case 'm':
-				toggleMute(node->name());
+				mute(node->name());
+				break;
+			case 'u':
+				unmute(node->name());
 				break;
 		}
 

--- a/rosmon_core/src/ui.h
+++ b/rosmon_core/src/ui.h
@@ -37,11 +37,17 @@ private:
 		Terminal::Parser parser;
 	};
 
+	enum FilterMode
+	{
+		Unfiltered = 0x1,
+		InclusiveFiltered = 0x2,
+		ExclusiveFiltered = 0x4
+	};
 	void drawStatusLine();
 	void checkWindowSize();
 	void setupColors();
 	void handleInput();
-	void toggleFilter(const std::string &nodeName);
+	void toggleFilter(const std::string &nodeName, FilterMode mode);
 
 	inline bool isFiltered(const std::string &s) 
 	{ return m_nodeFilterSet.find(s) != m_nodeFilterSet.end(); }
@@ -56,7 +62,7 @@ private:
 
 	std::set<std::string> m_nodeFilterSet;
 
-	bool m_filterSet;
+	FilterMode m_currentFilterMode;
 
 	std::map<std::string, ChannelInfo> m_nodeColorMap;
 

--- a/rosmon_core/src/ui.h
+++ b/rosmon_core/src/ui.h
@@ -37,7 +37,6 @@ private:
 		Terminal::Parser parser;
 	};
 
-
 	void drawStatusLine();
 	void checkWindowSize();
 	void setupColors();

--- a/rosmon_core/src/ui.h
+++ b/rosmon_core/src/ui.h
@@ -42,10 +42,21 @@ private:
 	void checkWindowSize();
 	void setupColors();
 	void handleInput();
-	void toggleMute(const std::string &nodeName);
 
 	inline bool isMuted(const std::string &s) 
 	{ return m_mutedSet.find(s) != m_mutedSet.end(); }
+
+	inline void mute(const std::string &s)
+	{ m_mutedSet.insert(s); }
+
+	inline void unmute(const std::string &s)
+	{ m_mutedSet.erase(s); }
+
+	inline void muteAll()
+	{ for(auto& node : m_monitor->nodes()) m_mutedSet.insert(node->name()); }
+
+	inline void unmuteAll()
+	{ m_mutedSet.clear(); }
 
 	monitor::Monitor* m_monitor;
 	FDWatcher::Ptr m_fdWatcher;

--- a/rosmon_core/src/ui.h
+++ b/rosmon_core/src/ui.h
@@ -11,6 +11,7 @@
 #include <ros/wall_timer.h>
 
 #include <map>
+#include <unordered_set>
 
 namespace rosmon
 {
@@ -68,7 +69,7 @@ private:
 	int m_columns;
 	ros::WallTimer m_sizeTimer;
 
-	std::set<std::string> m_mutedSet;
+	std::unordered_set<std::string> m_mutedSet;
 
 	std::map<std::string, ChannelInfo> m_nodeColorMap;
 

--- a/rosmon_core/src/ui.h
+++ b/rosmon_core/src/ui.h
@@ -43,6 +43,9 @@ private:
 	void setupColors();
 	void handleInput();
 
+	inline bool anyMuted()
+	{ return !m_mutedSet.empty(); }
+
 	inline bool isMuted(const std::string &s) 
 	{ return m_mutedSet.find(s) != m_mutedSet.end(); }
 

--- a/rosmon_core/src/ui.h
+++ b/rosmon_core/src/ui.h
@@ -37,20 +37,15 @@ private:
 		Terminal::Parser parser;
 	};
 
-	enum FilterMode
-	{
-		Unfiltered = 0x1,
-		InclusiveFiltered = 0x2,
-		ExclusiveFiltered = 0x4
-	};
+
 	void drawStatusLine();
 	void checkWindowSize();
 	void setupColors();
 	void handleInput();
-	void toggleFilter(const std::string &nodeName, FilterMode mode);
+	void toggleMute(const std::string &nodeName);
 
-	inline bool isFiltered(const std::string &s) 
-	{ return m_nodeFilterSet.find(s) != m_nodeFilterSet.end(); }
+	inline bool isMuted(const std::string &s) 
+	{ return m_mutedSet.find(s) != m_mutedSet.end(); }
 
 	monitor::Monitor* m_monitor;
 	FDWatcher::Ptr m_fdWatcher;
@@ -60,9 +55,7 @@ private:
 	int m_columns;
 	ros::WallTimer m_sizeTimer;
 
-	std::set<std::string> m_nodeFilterSet;
-
-	FilterMode m_currentFilterMode;
+	std::set<std::string> m_mutedSet;
 
 	std::map<std::string, ChannelInfo> m_nodeColorMap;
 

--- a/rosmon_core/src/ui.h
+++ b/rosmon_core/src/ui.h
@@ -41,6 +41,10 @@ private:
 	void checkWindowSize();
 	void setupColors();
 	void handleInput();
+	void toggleFilter(const std::string &nodeName);
+
+	inline bool isFiltered(const std::string &s) 
+	{ return m_nodeFilterSet.find(s) != m_nodeFilterSet.end(); }
 
 	monitor::Monitor* m_monitor;
 	FDWatcher::Ptr m_fdWatcher;
@@ -49,6 +53,10 @@ private:
 
 	int m_columns;
 	ros::WallTimer m_sizeTimer;
+
+	std::set<std::string> m_nodeFilterSet;
+
+	bool m_filterSet;
 
 	std::map<std::string, ChannelInfo> m_nodeColorMap;
 


### PR DESCRIPTION
I added a feature that allows the user to filter the ros log outputs on the node(s) they select. This only affects the ncurses ui, and does not propagate to the logging mechanism; just the ui output. Useful for specifically trying to debug a particular node that crashed by observing it's output if other nodes are producing too much output to easily see. 

Usage: 
Select node as usual, and press f to filter. The foreground text color will become white to denote filtered node. 
Upon filtering the first node, all other nodes will be filtered out until the last filtered node is unfiltered. 
To unfilter, select filtered node and press f again.

Did my best to keep variable naming conventions and bracketing consistent with source file.