### PR TITLE
Fix Rosmon build order

### DIFF
--- a/rosmon_core/CMakeLists.txt
+++ b/rosmon_core/CMakeLists.txt
@@ -89,6 +89,8 @@ target_link_libraries(rosmon
 	rosmon_launch_config
 )
 
+add_dependencies(rosmon ${catkin_EXPORTED_TARGETS})
+
 if(PYTHONLIBS_FOUND)
 	target_link_libraries(rosmon
 		${PYTHON_LIBRARIES}

--- a/rqt_rosmon/CMakeLists.txt
+++ b/rqt_rosmon/CMakeLists.txt
@@ -75,6 +75,8 @@ target_link_libraries(rqt_rosmon
 	${QT_LIBRARIES}
 )
 
+add_dependencies(rqt_rosmon ${catkin_EXPORTED_TARGETS})
+
 install(TARGETS rqt_rosmon
 	LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )


### PR DESCRIPTION
In the current master, it looks like if you build the whole package from scratch using `catkin_make` there is no guarantee that `rosmon_msgs` would be built first before `rqt_rosmon` or `rosmon_core`, resulting in dependency errors down the line. I added a couple lines in the `CMakeLists.txt` to ensure that there are proper dependencies for the build targets in both packages to `rosmon_msgs`