### PR TITLE
parse bool param case-insensitive

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -456,8 +456,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 
 static XmlRpc::XmlRpcValue autoXmlRpcValue(const std::string& fullValue)
 {
-	std::string fullValueLowercase(fullValue);
-	boost::algorithm::to_lower(fullValueLowercase);
+	std::string fullValueLowercase = boost::algorithm::to_lower_copy(fullValue);
 	if(fullValueLowercase == "true")
 		return XmlRpc::XmlRpcValue(true);
 	else if(fullValueLowercase == "false")
@@ -756,8 +755,7 @@ XmlRpc::XmlRpcValue LaunchConfig::paramToXmlRpc(const ParseContext& ctx, const s
 			return boost::lexical_cast<double>(value);
 		else if(type == "bool" || type == "boolean")
 		{
-			std::string value_lowercase(value);
-			boost::algorithm::to_lower(value_lowercase);
+			std::string value_lowercase = boost::algorithm::to_lower_copy(value);
 			if(value_lowercase == "true")
 				return true;
 			else if(value_lowercase == "false")

--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -16,6 +16,7 @@
 #include <sys/wait.h>
 
 #include <boost/regex.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -455,9 +456,11 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 
 static XmlRpc::XmlRpcValue autoXmlRpcValue(const std::string& fullValue)
 {
-	if(fullValue == "true")
+	std::string fullValueLowercase(fullValue);
+	boost::algorithm::to_lower(fullValueLowercase);
+	if(fullValueLowercase == "true")
 		return XmlRpc::XmlRpcValue(true);
-	else if(fullValue == "false")
+	else if(fullValueLowercase == "false")
 		return XmlRpc::XmlRpcValue(false);
 	else
 	{
@@ -753,9 +756,11 @@ XmlRpc::XmlRpcValue LaunchConfig::paramToXmlRpc(const ParseContext& ctx, const s
 			return boost::lexical_cast<double>(value);
 		else if(type == "bool" || type == "boolean")
 		{
-			if(value == "true")
+			std::string value_lowercase(value);
+			boost::algorithm::to_lower(value_lowercase);
+			if(value_lowercase == "true")
 				return true;
-			else if(value == "false")
+			else if(value_lowercase == "false")
 				return false;
 			else
 			{

--- a/rosmon_core/test/xml/test_arg.cpp
+++ b/rosmon_core/test/xml/test_arg.cpp
@@ -31,6 +31,7 @@ TEST_CASE("arg basic", "[arg]")
 
 	CHECK(getTypedParam<std::string>(params, "/arg1") == "hello world");
 	CHECK(getTypedParam<std::string>(params, "/arg2") == "hello world");
+	CHECK(getTypedParam<bool>(params, "/arg3") == true);
 }
 
 TEST_CASE("arg from external", "[arg]")

--- a/rosmon_core/test/xml/test_arg.cpp
+++ b/rosmon_core/test/xml/test_arg.cpp
@@ -17,9 +17,11 @@ TEST_CASE("arg basic", "[arg]")
 		<launch>
 			<arg name="arg1" value="hello world" />
 			<arg name="arg2" default="hello world" />
+			<arg name="arg3" default="True" />
 
 			<param name="arg1" value="$(arg arg1)" />
 			<param name="arg2" value="$(arg arg2)" />
+			<param name="arg3" type="bool" value="$(arg arg3)" />
 		</launch>
 	)EOF");
 

--- a/rosmon_core/test/xml/test_param.cpp
+++ b/rosmon_core/test/xml/test_param.cpp
@@ -44,8 +44,8 @@ TEST_CASE("param_types", "[param]")
 			<param name="str_param_auto" value="hello" />
 			<param name="str_param_forced" value="0" type="str" />
 
-			<param name="bool_param_auto" value="true" />
-			<param name="bool_param_forced" value="true" type="boolean" />
+			<param name="bool_param_auto" value="True" />
+			<param name="bool_param_forced" value="True" type="boolean" />
 
 			<param name="yaml_param" type="yaml" value="test_param: true" />
 			<param name="yaml_param_scalar" type="yaml" value="true" />

--- a/rosmon_core/test/xml/test_param.cpp
+++ b/rosmon_core/test/xml/test_param.cpp
@@ -44,8 +44,11 @@ TEST_CASE("param_types", "[param]")
 			<param name="str_param_auto" value="hello" />
 			<param name="str_param_forced" value="0" type="str" />
 
-			<param name="bool_param_auto" value="True" />
-			<param name="bool_param_forced" value="True" type="boolean" />
+			<param name="bool_param_auto" value="true" />
+			<param name="bool_param_forced" value="true" type="boolean" />
+
+			<param name="bool_param_auto_nonlowercase" value="True" />
+			<param name="bool_param_forced_nonlowercase" value="True" type="boolean" />
 
 			<param name="yaml_param" type="yaml" value="test_param: true" />
 			<param name="yaml_param_scalar" type="yaml" value="true" />
@@ -66,6 +69,9 @@ TEST_CASE("param_types", "[param]")
 
 	checkTypedParam<bool>(params, "/bool_param_auto", XmlRpc::XmlRpcValue::TypeBoolean, true);
 	checkTypedParam<bool>(params, "/bool_param_forced", XmlRpc::XmlRpcValue::TypeBoolean, true);
+
+	checkTypedParam<bool>(params, "/bool_param_auto_nonlowercase", XmlRpc::XmlRpcValue::TypeBoolean, true);
+	checkTypedParam<bool>(params, "/bool_param_forced_nonlowercase", XmlRpc::XmlRpcValue::TypeBoolean, true);
 
 	checkTypedParam<bool>(params, "/yaml_param/test_param", XmlRpc::XmlRpcValue::TypeBoolean, true);
 	checkTypedParam<bool>(params, "/yaml_param_scalar", XmlRpc::XmlRpcValue::TypeBoolean, true);


### PR DESCRIPTION
Non-lowercase bool values were partially addressed here: https://github.com/xqms/rosmon/pull/27/commits/488c8c03885dd73b878355b583371ecffb3c557b

This adds "True" input to some unit tests and converts to lowercase before comparing to true or false.