### PR TITLE
rosmon_core: monitor: remove `exists` check for /proc/.../stat

### DIFF
--- a/rosmon_core/src/monitor/monitor.cpp
+++ b/rosmon_core/src/monitor/monitor.cpp
@@ -184,8 +184,6 @@ void Monitor::updateStats()
 	for(; it != end; ++it)
 	{
 		fs::path statPath = (*it) / "stat";
-		if(!fs::exists(statPath))
-			continue;
 
 		process_info::ProcessStat stat;
 		if(!process_info::readStatFile(statPath.c_str(), &stat))


### PR DESCRIPTION
We use boost::filesystem to check if the stat file exists. It seems that
`fs::exists` handles ESRCH (which procfs may return in some cases, see #81)
as an exception, which is then unhandled by us.

Instead of catching the exception, we can just remove the check since
`readStatFile()` handles any error on opening the stat file correctly and
causes a `continue` in the process iteration loop.

This should fix #81.