### PR TITLE
Trim & simplify whitespace in substitution contexts

### DIFF
--- a/rosmon_core/CMakeLists.txt
+++ b/rosmon_core/CMakeLists.txt
@@ -58,7 +58,8 @@ add_library(rosmon_launch_config
 	src/launch/substitution.cpp
 	src/launch/substitution_python.cpp
 	src/launch/yaml_params.cpp
-        src/launch/bytes_parser.cpp
+	src/launch/bytes_parser.cpp
+	src/launch/string_utils.cpp
 	src/package_registry.cpp
 )
 target_link_libraries(rosmon_launch_config

--- a/rosmon_core/src/launch/string_utils.cpp
+++ b/rosmon_core/src/launch/string_utils.cpp
@@ -1,0 +1,62 @@
+// String utilities
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include "string_utils.h"
+
+namespace rosmon
+{
+namespace launch
+{
+namespace string_utils
+{
+
+std::string simplifyWhitespace(const std::string& input)
+{
+	std::string output;
+	output.reserve(input.size());
+
+	// Skip initial space
+	size_t i = 0;
+	for(; i < input.size(); ++i)
+	{
+		if(!std::isspace(static_cast<unsigned char>(input[i])))
+			break;
+	}
+
+	bool in_space = false;
+
+	for(; i < input.size(); ++i)
+	{
+		char c = input[i];
+
+		if(std::isspace(static_cast<unsigned char>(c)))
+			in_space = true;
+		else
+		{
+			if(in_space)
+				output.push_back(' ');
+
+			output.push_back(c);
+			in_space = false;
+		}
+	}
+
+	return output;
+}
+
+bool isOnlyWhitespace(const std::string& input)
+{
+	for(const char& c: input)
+	{
+		// see http://en.cppreference.com/w/cpp/string/byte/isspace
+		// for reason for casting
+		if(!std::isspace(static_cast<unsigned char>(c)))
+			return false;
+	}
+
+	return true;
+}
+
+}
+}
+}

--- a/rosmon_core/src/launch/string_utils.h
+++ b/rosmon_core/src/launch/string_utils.h
@@ -1,0 +1,35 @@
+// String utilities
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#ifndef ROSMON_LAUNCH_STRING_UTILS_H
+#define ROSMON_LAUNCH_STRING_UTILS_H
+
+#include <string>
+
+namespace rosmon
+{
+namespace launch
+{
+namespace string_utils
+{
+
+/**
+ * @brief Compress any sequence of whitespace to single spaces.
+ *
+ * Since we switch of space condensing in TinyXML to be able to properly parse
+ * <rosparam> tags, this function can be used for attributes.
+ *
+ * roslaunch also strips whitespace at begin/end, so we do that as well.
+ **/
+std::string simplifyWhitespace(const std::string& input);
+
+/**
+ * @brief Check if string is whitespace only (includes '\n')
+ **/
+bool isOnlyWhitespace(const std::string& input);
+
+}
+}
+}
+
+#endif

--- a/rosmon_core/src/launch/substitution.cpp
+++ b/rosmon_core/src/launch/substitution.cpp
@@ -3,6 +3,7 @@
 
 #include "substitution.h"
 #include "substitution_python.h"
+#include "string_utils.h"
 
 #include "launch_config.h"
 #include "../package_registry.h"
@@ -128,6 +129,10 @@ static std::string parseOneElement(const std::string& input, const HandlerMap& h
 					std::string args;
 					if(pos != std::string::npos)
 						args = contents.substr(pos+1);
+
+					// Remove leading/trailing whitespace and simplify any
+					// internal whitespace
+					args = string_utils::simplifyWhitespace(args);
 
 					auto it = handlers.find(name);
 					if(it != handlers.end())

--- a/rosmon_core/test/xml/test_arg.cpp
+++ b/rosmon_core/test/xml/test_arg.cpp
@@ -74,3 +74,27 @@ TEST_CASE("arg unset", "[arg]")
 		</launch>
 	)EOF");
 }
+
+TEST_CASE("arg whitespace", "[arg]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<arg name="arg1" value="hello world" />
+			<arg name="arg2" default="hello world" />
+			<arg name="arg3" default="True" />
+
+			<param name="arg1" value="$(arg arg1 )" />
+			<param name="arg2" value="$(arg  arg2)" />
+			<param name="arg3" type="bool" value="$(arg  arg3  )" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto params = config.parameters();
+
+	CHECK(getTypedParam<std::string>(params, "/arg1") == "hello world");
+	CHECK(getTypedParam<std::string>(params, "/arg2") == "hello world");
+	CHECK(getTypedParam<bool>(params, "/arg3") == true);
+}


### PR DESCRIPTION
`roslaunch` parses weird stuff like `$(arg    my_arg     )` without problems, so we should, too.

This fixes #83.