### PR TITLE
Handle lowercase true/false in $(eval) expressions

### DIFF
--- a/rosmon_core/src/launch/substitution_python.cpp
+++ b/rosmon_core/src/launch/substitution_python.cpp
@@ -121,6 +121,12 @@ std::string evaluatePython(const std::string& input, ParseContext& context)
 		global.update(mathDict);
 	}
 
+	// Lowercase booleans (why, roslaunch?)
+	{
+		global["true"] = py::object(true);
+		global["false"] = py::object(false);
+	}
+
 	py::object result;
 	try
 	{

--- a/rosmon_core/test/xml/test_subst.cpp
+++ b/rosmon_core/test/xml/test_subst.cpp
@@ -297,6 +297,22 @@ TEST_CASE("eval", "[subst]")
 			</launch>
 		)EOF");
 	}
+
+	SECTION("lowercase booleans")
+	{
+		LaunchConfig config;
+		config.parseString(R"EOF(
+			<launch>
+				<arg name="input" default="false" />
+				<param name="output" value="$(eval input == true)"/>
+			</launch>
+		)EOF");
+
+		config.evaluateParameters();
+
+		auto value = getTypedParam<bool>(config.parameters(), "/output");
+		CHECK(value == false);
+	}
 }
 
 TEST_CASE("dirname", "[subst]")


### PR DESCRIPTION
For compatibility with `roslaunch`.

Fixes #84.