### PR TITLE
rosmon_core: monitor: make fork() operation safe using external shim

### DIFF
--- a/rosmon_core/CMakeLists.txt
+++ b/rosmon_core/CMakeLists.txt
@@ -70,6 +70,13 @@ target_link_libraries(rosmon_launch_config
 	yaml-cpp
 )
 
+add_executable(_shim
+	src/monitor/shim.cpp
+)
+target_link_libraries(_shim
+	util
+)
+
 add_executable(rosmon
 	src/main.cpp
 	src/monitor/node_monitor.cpp

--- a/rosmon_core/src/monitor/node_monitor.cpp
+++ b/rosmon_core/src/monitor/node_monitor.cpp
@@ -29,14 +29,56 @@
 
 #define TASK_COMM_LEN 16 // from linux/sched.h
 
-template<typename... Args>
-std::runtime_error error(const char* fmt, const Args& ... args)
+namespace
 {
-	return std::runtime_error(fmt::format(fmt, args...));
-}
+	template<typename... Args>
+	std::runtime_error error(const char* fmt, const Args& ... args)
+	{
+		return std::runtime_error(fmt::format(fmt, args...));
+	}
 
-static bool g_coreIsRelative = true;
-static bool g_coreIsRelative_valid = false;
+	// finally() from C++ core guidelines
+	template <class F>
+	class final_act
+	{
+	public:
+		explicit final_act(F f) noexcept
+		: f_(std::move(f)), invoke_(true) {}
+
+		final_act(final_act&& other) noexcept
+		: f_(std::move(other.f_)),
+		invoke_(other.invoke_)
+		{
+			other.invoke_ = false;
+		}
+
+		final_act(const final_act&) = delete;
+		final_act& operator=(const final_act&) = delete;
+
+		~final_act() noexcept
+		{
+			if (invoke_) f_();
+		}
+
+	private:
+		F f_;
+		bool invoke_;
+	};
+	template <class F>
+	inline final_act<F> finally(const F& f) noexcept
+	{
+		return final_act<F>(f);
+	}
+
+	template <class F>
+	inline final_act<F> finally(F&& f) noexcept
+	{
+		return final_act<F>(std::forward<F>(f));
+	}
+
+	static bool g_coreIsRelative = true;
+	static bool g_coreIsRelative_valid = false;
+}
 
 namespace rosmon
 {
@@ -141,67 +183,73 @@ void NodeMonitor::start()
 
 	ROS_INFO("rosmon: starting '%s'", m_launchNode->name().c_str());
 
-	int pid = forkpty(&m_fd, nullptr, nullptr, nullptr);
+	std::vector<std::string> cmd = composeCommand();
+
+	std::vector<char*> args;
+	auto argsCleaner = finally([&args](){
+		for(char* arg : args)
+			free(arg);
+	});
+
+	// Open pseudo-terminal
+	// NOTE: We are not using forkpty() here, as it is probably not safe in
+	//  a multi-threaded process (see
+	//  https://www.linuxprogrammingblog.com/threads-and-fork-think-twice-before-using-them)
+	int master, slave;
+
+	if(openpty(&master, &slave, nullptr, nullptr, nullptr) == -1)
+		throw error("Could not open pseudo terminal for child process: {}", strerror(errno));
+
+	// Compose args
+	{
+		args.push_back(strdup("rosrun"));
+		args.push_back(strdup("rosmon_core"));
+		args.push_back(strdup("_shim"));
+
+		args.push_back(strdup("--tty"));
+		args.push_back(strdup(fmt::format("{}", slave).c_str()));
+
+		if(!m_launchNode->namespaceString().empty())
+		{
+			args.push_back(strdup("--namespace"));
+			args.push_back(strdup(m_launchNode->namespaceString().c_str()));
+		}
+
+		for(auto& pair : m_launchNode->extraEnvironment())
+		{
+			args.push_back(strdup("--env"));
+			args.push_back(strdup(fmt::format("{}={}", pair.first, pair.second).c_str()));
+		}
+
+		if(m_launchNode->coredumpsEnabled())
+		{
+			args.push_back(strdup("--coredump"));
+
+			if(g_coreIsRelative)
+			{
+				args.push_back(strdup("--coredump-relative"));
+				args.push_back(strdup(m_processWorkingDirectory.c_str()));
+			}
+		}
+
+		args.push_back(strdup("--run"));
+
+		for(auto& c : cmd)
+			args.push_back(strdup(c.c_str()));
+
+		args.push_back(nullptr);
+	}
+
+	// Fork!
+	int pid = fork();
 	if(pid < 0)
-		throw error("Could not fork with forkpty(): {}", strerror(errno));
+		throw error("Could not fork(): {}", strerror(errno));
 
 	if(pid == 0)
 	{
-		std::vector<std::string> cmd = composeCommand();
+		close(master);
 
-		char* path = strdup(cmd[0].c_str());
-
-		std::vector<char*> ptrs(cmd.size());
-
-		for(unsigned int i = 0; i < cmd.size(); ++i)
-			ptrs[i] = strdup(cmd[i].data());
-		ptrs.push_back(nullptr);
-
-		if(!m_launchNode->namespaceString().empty())
-			setenv("ROS_NAMESPACE", m_launchNode->namespaceString().c_str(), 1);
-
-		for(auto& pair : m_launchNode->extraEnvironment())
-			setenv(pair.first.c_str(), pair.second.c_str(), 1);
-
-		// Try to enable core dumps
-		if(m_launchNode->coredumpsEnabled())
-		{
-			rlimit limit;
-			if(getrlimit(RLIMIT_CORE, &limit) == 0)
-			{
-				// only modify the limit if coredumps are disabled entirely
-				if(limit.rlim_cur == 0)
-				{
-					limit.rlim_cur = limit.rlim_max;
-					setrlimit(RLIMIT_CORE, &limit);
-				}
-			}
-
-			// If needed for coredump collection with a relative core_pattern,
-			// cd to a temporary directory.
-			if(g_coreIsRelative)
-			{
-				if(chdir(m_processWorkingDirectory.c_str()) != 0)
-				{
-					perror("Could not change to newly created process working directory");
-				}
-			}
-		}
-		else
-		{
-			// Disable coredumps
-			rlimit limit;
-			if(getrlimit(RLIMIT_CORE, &limit) == 0)
-			{
-				limit.rlim_cur = 0;
-				setrlimit(RLIMIT_CORE, &limit);
-			}
-		}
-
-		// Allow gdb to attach
-		prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY);
-
-		if(execvp(path, ptrs.data()) != 0)
+		if(execvp("rosrun", args.data()) != 0)
 		{
 			std::stringstream ss;
 			for(const auto& part : cmd)
@@ -215,6 +263,9 @@ void NodeMonitor::start()
 	}
 
 	// Parent
+	close(slave);
+
+	m_fd = master;
 	m_pid = pid;
 	m_fdWatcher->registerFD(m_fd, boost::bind(&NodeMonitor::communicate, this));
 }

--- a/rosmon_core/src/monitor/shim.cpp
+++ b/rosmon_core/src/monitor/shim.cpp
@@ -1,0 +1,176 @@
+// Sets up a node process environment and executes the target node
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include <stdexcept>
+#include <vector>
+#include <sstream>
+
+#include <unistd.h>
+#include <getopt.h>
+#include <string.h>
+
+#include <utmp.h>
+
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/prctl.h>
+
+static const struct option OPTIONS[] = {
+	{"help", no_argument, nullptr, 'h'},
+	{"namespace", required_argument, nullptr, 'n'},
+	{"env", required_argument, nullptr, 'e'},
+	{"coredump", no_argument, nullptr, 'c'},
+	{"coredump-relative", required_argument, nullptr, 'C'},
+	{"tty", required_argument, nullptr, 't'},
+	{"run", required_argument, nullptr, 'r'},
+
+	{nullptr, 0, nullptr, 0}
+};
+
+void usage()
+{
+	fprintf(stderr, R"EOS(
+This is an internal tool for rosmon. You should not need to call it yourself.
+
+Usage:
+  _shim [options] --run <executable> [args...]
+
+Options:
+  --namespace=NS           Put the node in namespace NS
+  --env=A=B                Set environment variable A to value B (can be repeated)
+  --coredump               Enable coredump collection
+  --coredump-relative=DIR  Coredumps should go to DIR
+  --run <executable>       All arguments after this one are passed on
+)EOS");
+}
+
+int main(int argc, char** argv)
+{
+	bool coredumpsEnabled = false;
+	char* coredumpsRelative = nullptr;
+
+	char* nodeExecutable = nullptr;
+	int nodeOptionsBegin = -1;
+
+	int tty = -1;
+
+	while(true)
+	{
+		int option_index;
+		int c = getopt_long(argc, argv, "h", OPTIONS, &option_index);
+
+		if(c == -1)
+			break;
+
+		switch(c)
+		{
+			case 'h':
+				usage();
+				return 0;
+			case '?':
+				usage();
+				return 1;
+			case 'n':
+				setenv("ROS_NAMESPACE", optarg, 1);
+				break;
+			case 'e':
+			{
+				char* value = strchr(optarg, '=');
+				if(!value)
+					throw std::invalid_argument("Need '=' in --env spec");
+
+				*value = 0;
+
+				setenv(optarg, value + 1, 1);
+				break;
+			}
+			case 'c':
+				coredumpsEnabled = true;
+				break;
+			case 'C':
+				coredumpsRelative = optarg;
+				break;
+			case 't':
+				tty = atoi(optarg);
+				break;
+			case 'r':
+				nodeExecutable = optarg;
+				nodeOptionsBegin = optind;
+				break;
+		}
+
+		if(nodeExecutable)
+			break;
+	}
+
+	if(!nodeExecutable)
+		throw std::invalid_argument("Need --run option");
+
+	if(tty < 0)
+		throw std::invalid_argument("Need --tty option");
+
+	if(login_tty(tty) != 0)
+	{
+		perror("Could not call login_tty()");
+		std::abort();
+	}
+
+	// Try to enable core dumps
+	if(coredumpsEnabled)
+	{
+		rlimit limit;
+		if(getrlimit(RLIMIT_CORE, &limit) == 0)
+		{
+			// only modify the limit if coredumps are disabled entirely
+			if(limit.rlim_cur == 0)
+			{
+				limit.rlim_cur = limit.rlim_max;
+				setrlimit(RLIMIT_CORE, &limit);
+			}
+		}
+
+		// If needed for coredump collection with a relative core_pattern,
+		// cd to a temporary directory.
+		if(coredumpsRelative)
+		{
+			if(chdir(coredumpsRelative) != 0)
+			{
+				perror("Could not change to newly created process working directory");
+			}
+		}
+	}
+	else
+	{
+		// Disable coredumps
+		rlimit limit;
+		if(getrlimit(RLIMIT_CORE, &limit) == 0)
+		{
+			limit.rlim_cur = 0;
+			setrlimit(RLIMIT_CORE, &limit);
+		}
+	}
+
+	// Allow gdb to attach
+	prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY);
+
+	// Build up argument vector
+	std::vector<char*> args;
+
+	args.push_back(nodeExecutable);
+
+	for(int i = nodeOptionsBegin; i < argc; ++i)
+		args.push_back(argv[i]);
+
+	// Go!
+	if(execvp(nodeExecutable, args.data()) != 0)
+	{
+		std::stringstream ss;
+		for(const auto& part : args)
+			ss << part << " ";
+
+		fprintf(stderr, "Could not execute %s: %s\n", ss.str().c_str(), strerror(errno));
+	}
+
+	// We should not arrive here
+	std::abort();
+}


### PR DESCRIPTION
After fork(), we should only use signal-safe standard library methods. So do all the complicated steps in an external executable that is executed first.

This fixes #88.