### PR TITLE
Handle nesting with $(anon) subst correctly

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -118,6 +118,20 @@ void ParseContext::setRemap(const std::string& from, const std::string& to)
 	m_remappings[from] = to;
 }
 
+std::string ParseContext::anonName(const std::string& base)
+{
+	auto it = m_anonNames.find(base);
+	if(it == m_anonNames.end())
+	{
+		auto name = base + "_" + m_config->generateAnonHash();
+
+		it = m_anonNames.emplace(base, name).first;
+	}
+
+	return it->second;
+}
+
+
 LaunchConfig::LaunchConfig()
  : m_rootContext(this)
  , m_anonGen(std::random_device()())
@@ -1009,22 +1023,9 @@ void LaunchConfig::parseRemap(TiXmlElement* element, ParseContext& ctx)
 	ctx.setRemap(ctx.evaluate(from), ctx.evaluate(to));
 }
 
-std::string LaunchConfig::anonName(const std::string& base)
+std::string LaunchConfig::generateAnonHash()
 {
-	auto it = m_anonNames.find(base);
-	if(it == m_anonNames.end())
-	{
-		uint32_t r = m_anonGen();
-
-		char buf[20];
-		snprintf(buf, sizeof(buf), "%08X", r);
-
-		auto name = base + "_" + buf;
-
-		it = m_anonNames.emplace(base, name).first;
-	}
-
-	return it->second;
+	return fmt::format("{:08X}", m_anonGen());
 }
 
 template<class Iterator>

--- a/rosmon_core/src/launch/launch_config.h
+++ b/rosmon_core/src/launch/launch_config.h
@@ -198,9 +198,9 @@ private:
 	void parseTopLevelAttributes(TiXmlElement* element);
 
 	void parse(TiXmlElement* element, ParseContext* ctx, bool onlyArguments = false);
-	void parseNode(TiXmlElement* element, ParseContext ctx);
-	void parseParam(TiXmlElement* element, ParseContext ctx, ParamContext paramContext = PARAM_GENERAL);
-	void parseROSParam(TiXmlElement* element, ParseContext ctx);
+	void parseNode(TiXmlElement* element, ParseContext& ctx);
+	void parseParam(TiXmlElement* element, ParseContext& ctx, ParamContext paramContext = PARAM_GENERAL);
+	void parseROSParam(TiXmlElement* element, ParseContext& ctx);
 	void parseInclude(TiXmlElement* element, ParseContext ctx);
 	void parseArgument(TiXmlElement* element, ParseContext& ctx);
 	void parseEnv(TiXmlElement* element, ParseContext& ctx);

--- a/rosmon_core/src/launch/launch_config.h
+++ b/rosmon_core/src/launch/launch_config.h
@@ -107,6 +107,8 @@ public:
 	const std::map<std::string, std::string>& remappings()
 	{ return m_remappings; }
 
+	std::string anonName(const std::string& base);
+
 	template<typename... Args>
 	ParseException error(const char* fmt, const Args& ... args) const
 	{
@@ -147,6 +149,7 @@ private:
 	std::map<std::string, std::string> m_args;
 	std::map<std::string, std::string> m_environment;
 	std::map<std::string, std::string> m_remappings;
+	std::map<std::string, std::string> m_anonNames;
 };
 
 class LaunchConfig
@@ -188,6 +191,8 @@ public:
 
 	std::string windowTitle() const
 	{ return m_windowTitle; }
+
+	std::string generateAnonHash();
 private:
 	enum ParamContext
 	{
@@ -227,7 +232,6 @@ private:
 	std::map<std::string, ParameterFuture> m_paramJobs;
 	std::vector<std::future<YAMLResult>> m_yamlParamJobs;
 
-	std::map<std::string, std::string> m_anonNames;
 	std::mt19937_64 m_anonGen;
 
 	std::string m_rosmonNodeName;

--- a/rosmon_core/src/launch/substitution.cpp
+++ b/rosmon_core/src/launch/substitution.cpp
@@ -37,7 +37,7 @@ namespace substitutions
 		std::string base = name;
 		boost::trim(base);
 
-		return context.config()->anonName(base);
+		return context.anonName(base);
 	}
 
 	std::string arg(const std::string& name, const ParseContext& context)

--- a/rosmon_core/test/xml/node_utils.cpp
+++ b/rosmon_core/test/xml/node_utils.cpp
@@ -25,6 +25,12 @@ rosmon::launch::Node::Ptr getNode(const std::vector<rosmon::launch::Node::Ptr>& 
 	rosmon::launch::Node::Ptr ret;
 
 	INFO("Looking for node '" << name << "' in namespace '" << namespaceString << "'");
+	INFO("Node list:");
+
+	std::stringstream ss;
+	for(auto& node : nodes)
+		ss << " - '" << node->name() << "' (ns '" << node->namespaceString() << "')\n";
+	INFO(ss.str());
 
 	for(auto& node : nodes)
 	{

--- a/rosmon_core/test/xml/test_subst.cpp
+++ b/rosmon_core/test/xml/test_subst.cpp
@@ -175,6 +175,35 @@ TEST_CASE("anon", "[subst]")
 			</launch>
 		)EOF");
 	}
+
+	SECTION("nested")
+	{
+		LaunchConfig config;
+		config.parseString(R"EOF(
+			<launch>
+				<param name="test_1_global" value="$(anon test_1)" />
+
+				<group>
+					<param name="test_1_local" value="$(anon test_1)" />
+					<param name="test_2_local" value="$(anon test_2)" />
+				</group>
+
+				<param name="test_2_global" value="$(anon test_2)" />
+			</launch>
+		)EOF");
+
+		config.evaluateParameters();
+
+		CAPTURE(config.parameters());
+
+		auto test_1_global = getTypedParam<std::string>(config.parameters(), "/test_1_global");
+		auto test_1_local = getTypedParam<std::string>(config.parameters(), "/test_1_local");
+		auto test_2_global = getTypedParam<std::string>(config.parameters(), "/test_2_global");
+		auto test_2_local = getTypedParam<std::string>(config.parameters(), "/test_2_local");
+
+		CHECK(test_1_global == test_1_local);
+		CHECK(test_2_global != test_2_local);
+	}
 }
 
 TEST_CASE("arg", "[subst]")


### PR DESCRIPTION
Basically, we need to handle `$(anon)` in the parse context, since it has scope. See #100 for detailed issue description.

This PR also changes a lot of the attribute parsing code (attributes need to be evaluated outside of their element's context for this to work). Needs verification in more complex setups.