### PR TITLE
rosmon_core: Correctly terminate execvp() arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: generic
+services:
+  - docker
+
+env:
+  global:
+    - CMAKE_ARGS="-DCMAKE_CXX_FLAGS='-fsanitize=address -fsanitize=leak'"
+  matrix:
+    - ROS_DISTRO="melodic"
+
+install:
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci
+script:
+  - .industrial_ci/travis.sh
+

--- a/rosmon_core/src/monitor/shim.cpp
+++ b/rosmon_core/src/monitor/shim.cpp
@@ -161,6 +161,8 @@ int main(int argc, char** argv)
 	for(int i = nodeOptionsBegin; i < argc; ++i)
 		args.push_back(argv[i]);
 
+	args.push_back(nullptr);
+
 	// Go!
 	if(execvp(nodeExecutable, args.data()) != 0)
 	{


### PR DESCRIPTION
See #102 for report. This also adds a travis CI job with `-fsanitize=address` to check this. While ASan does not report a failure, it seems to reliably trigger the bug.