### PR TITLE
Parse output node tag

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -286,6 +286,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 	const char* stopTimeout = element->Attribute("rosmon-stop-timeout");
     const char* memoryLimit = element->Attribute("rosmon-memory-limit");
     const char* cpuLimit = element->Attribute("rosmon-cpu-limit");
+	const char* output = element->Attribute("output");
 
 
 	if(!name || !pkg || !type)
@@ -445,6 +446,11 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 		node->setClearParams(ctx.parseBool(clearParams, element->Row()));
 
 	node->setRemappings(ctx.remappings());
+
+		if(!output || ctx.evaluate(output) != "screen")
+		{
+			node->setMutedDefault(true);
+		}
 
 	m_nodes.push_back(node);
 }

--- a/rosmon_core/src/launch/node.cpp
+++ b/rosmon_core/src/launch/node.cpp
@@ -29,6 +29,7 @@ Node::Node(std::string name, std::string package, std::string type)
  : m_name(std::move(name))
  , m_package(std::move(package))
  , m_type(std::move(type))
+ , m_muted(false)
 
  // NOTE: roslaunch documentation seems to suggest that this is true by default,
  //  however, the source tells a different story...

--- a/rosmon_core/src/launch/node.h
+++ b/rosmon_core/src/launch/node.h
@@ -46,6 +46,11 @@ public:
 
     void setCPULimit(float cpuLimit);
 
+	void setMutedDefault(bool muted)
+	{
+		m_muted = muted;
+	}
+
 	std::string name() const
 	{ return m_name; }
 
@@ -101,6 +106,10 @@ public:
 
     float cpuLimit()const
     { return m_cpuLimit; }
+
+	bool isMuted()const
+	{return m_muted; }
+
 private:
 	std::string m_name;
 	std::string m_package;
@@ -132,6 +141,8 @@ private:
 
     uint64_t m_memoryLimitByte;
     float m_cpuLimit;
+
+	bool m_muted;
 };
 
 }

--- a/rosmon_core/src/main.cpp
+++ b/rosmon_core/src/main.cpp
@@ -86,6 +86,8 @@ void usage()
         "                  CPU usage.\n"
         "  --memory-limit=15MB\n"
         "                  Default memory limit usage of monitored process.\n"
+		"  --obey-output\n"
+		"                  Obey node output tag. It mutes a node by default unless output=screen is set\n"
 		"\n"
 		"rosmon also obeys some environment variables:\n"
 		"  ROSMON_COLOR_MODE   Can be set to 'truecolor', '256colors', 'ansi'\n"
@@ -131,6 +133,7 @@ static const struct option OPTIONS[] = {
     {"cpu-limit", required_argument, nullptr, 'c'},
     {"memory-limit", required_argument, nullptr, 'm'},
     {"diagnostics-prefix", required_argument, nullptr, 'p'},
+	{"obey-output", no_argument, nullptr, 'o'},
 	{nullptr, 0, nullptr, 0}
 };
 
@@ -155,6 +158,7 @@ int main(int argc, char** argv)
 	float cpuLimit = rosmon::launch::LaunchConfig::DEFAULT_CPU_LIMIT;
 	bool disableDiagnostics = false;
 	std::string diagnosticsPrefix;
+	bool obey_output = false;
 
 	// Parse options
 	while(true)
@@ -246,6 +250,8 @@ int main(int argc, char** argv)
 				fmt::print(stderr, "Prefix : {}", optarg);
 				diagnosticsPrefix = std::string(optarg);
 				break;
+			case 'o':
+				obey_output = true;
 		}
 	}
 
@@ -439,9 +445,12 @@ int main(int argc, char** argv)
 
 	//Get muted nodes by default
 	std::unordered_set<std::string> muted_nodes;
-	for(const auto & n : config->nodes()){
-		if(n->isMuted()){
-			muted_nodes.insert(n->name());
+	if(obey_output)
+	{
+		for(const auto & n : config->nodes())
+		{
+			if(n->isMuted())
+				muted_nodes.insert(n->name());
 		}
 	}
 

--- a/rosmon_core/src/main.cpp
+++ b/rosmon_core/src/main.cpp
@@ -437,6 +437,14 @@ int main(int argc, char** argv)
 		return 0;
 	}
 
+	//Get muted nodes by default
+	std::unordered_set<std::string> muted_nodes;
+	for(const auto & n : config->nodes()){
+		if(n->isMuted()){
+			muted_nodes.insert(n->name());
+		}
+	}
+
 	// Should we automatically start the nodes?
 	if(startNodes)
 		monitor.start();
@@ -445,7 +453,7 @@ int main(int argc, char** argv)
 	boost::scoped_ptr<rosmon::UI> ui;
 	if(enableUI)
 	{
-		ui.reset(new rosmon::UI(&monitor, watcher));
+		ui.reset(new rosmon::UI(&monitor, watcher, muted_nodes));
 	}
 	else
 	{

--- a/rosmon_core/src/ui.cpp
+++ b/rosmon_core/src/ui.cpp
@@ -33,10 +33,11 @@ void cleanup()
 namespace rosmon
 {
 
-UI::UI(monitor::Monitor* monitor, const FDWatcher::Ptr& fdWatcher)
+UI::UI(monitor::Monitor* monitor, const FDWatcher::Ptr& fdWatcher,const std::unordered_set<std::string>& muted)
  : m_monitor(monitor)
  , m_fdWatcher(fdWatcher)
  , m_columns(80)
+ , m_mutedSet(muted)
  , m_selectedNode(-1)
 {
 	std::atexit(cleanup);

--- a/rosmon_core/src/ui.h
+++ b/rosmon_core/src/ui.h
@@ -20,7 +20,7 @@ namespace rosmon
 class UI
 {
 public:
-	explicit UI(monitor::Monitor* monitor, const FDWatcher::Ptr& fdWatcher);
+	explicit UI(monitor::Monitor* monitor, const FDWatcher::Ptr& fdWatcher, const std::unordered_set<std::string>& muted = std::unordered_set<std::string>());
 	~UI();
 
 	void update();


### PR DESCRIPTION
We need to parse the node tag output ("log|screen") so we can mute nodes by default.

This PR mutes by default all nodes without attribute output="screen".

