### PR TITLE
Option to obey output=XY tags

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -300,6 +300,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext& attr_ctx)
 	const char* stopTimeout = element->Attribute("rosmon-stop-timeout");
 	const char* memoryLimit = element->Attribute("rosmon-memory-limit");
 	const char* cpuLimit = element->Attribute("rosmon-cpu-limit");
+	const char* output = element->Attribute("output");
 
 	if(!name || !pkg || !type)
 	{
@@ -459,6 +460,22 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext& attr_ctx)
 
 	if(clearParams)
 		node->setClearParams(attr_ctx.parseBool(clearParams, element->Row()));
+
+	if(m_outputAttrMode == OutputAttr::Obey)
+	{
+		node->setMuted(true); // output=log is default
+
+		if(output)
+		{
+			std::string outputStr = attr_ctx.evaluate(output);
+			if(outputStr == "screen")
+				node->setMuted(false);
+			else if(outputStr == "log")
+				node->setMuted(true);
+			else
+				throw ctx.error("Invalid output attribute value: '{}'", outputStr);
+		}
+	}
 
 	node->setRemappings(ctx.remappings());
 
@@ -1109,6 +1126,11 @@ void LaunchConfig::evaluateParameters()
 		throw caughtException;
 
 	m_paramJobs.clear();
+}
+
+void LaunchConfig::setOutputAttrMode(OutputAttr mode)
+{
+	m_outputAttrMode = mode;
 }
 
 }

--- a/rosmon_core/src/launch/launch_config.h
+++ b/rosmon_core/src/launch/launch_config.h
@@ -164,11 +164,19 @@ public:
 
 	LaunchConfig();
 
+	enum class OutputAttr
+	{
+		Obey,
+		Ignore
+	};
+
 	void setArgument(const std::string& name, const std::string& value);
 
 	void setDefaultStopTimeout(double timeout);
 	void setDefaultCPULimit(double CPULimit);
 	void setDefaultMemoryLimit(uint64_t memoryLimit);
+
+	void setOutputAttrMode(OutputAttr mode);
 
 	void parse(const std::string& filename, bool onlyArguments = false);
 	void parseString(const std::string& input, bool onlyArguments = false);
@@ -241,6 +249,8 @@ private:
 	double m_defaultStopTimeout{DEFAULT_STOP_TIMEOUT};
 	uint64_t m_defaultMemoryLimit{DEFAULT_MEMORY_LIMIT};
 	double m_defaultCPULimit{DEFAULT_CPU_LIMIT};
+
+	OutputAttr m_outputAttrMode{OutputAttr::Ignore};
 };
 
 }

--- a/rosmon_core/src/launch/node.cpp
+++ b/rosmon_core/src/launch/node.cpp
@@ -41,6 +41,7 @@ Node::Node(std::string name, std::string package, std::string type)
  , m_stopTimeout(5.0)
  , m_memoryLimitByte(15e6)
  , m_cpuLimit(0.05)
+ , m_muted(false)
 {
 	m_executable = PackageRegistry::getExecutable(m_package, m_type);
 }
@@ -153,6 +154,11 @@ void Node::setMemoryLimit(uint64_t memoryLimitByte)
 void Node::setCPULimit(float cpuLimit)
 {
 	m_cpuLimit = cpuLimit;
+}
+
+void Node::setMuted(bool muted)
+{
+	m_muted = muted;
 }
 
 }

--- a/rosmon_core/src/launch/node.h
+++ b/rosmon_core/src/launch/node.h
@@ -46,6 +46,8 @@ public:
 
 	void setCPULimit(float cpuLimit);
 
+	void setMuted(bool muted);
+
 	std::string name() const
 	{ return m_name; }
 
@@ -102,6 +104,8 @@ public:
 	float cpuLimit() const
 	{ return m_cpuLimit; }
 
+	bool isMuted() const
+	{ return m_muted; }
 private:
 	std::string m_name;
 	std::string m_package;
@@ -133,6 +137,8 @@ private:
 
 	uint64_t m_memoryLimitByte;
 	float m_cpuLimit;
+
+	bool m_muted;
 };
 
 }

--- a/rosmon_core/src/log_event.h
+++ b/rosmon_core/src/log_event.h
@@ -31,6 +31,7 @@ public:
 	std::string source;
 	std::string message;
 	Type type;
+	bool muted = false;
 };
 
 }

--- a/rosmon_core/src/main.cpp
+++ b/rosmon_core/src/main.cpp
@@ -86,6 +86,9 @@ void usage()
 		"                  CPU usage.\n"
 		"  --memory-limit=15MB\n"
 		"                  Default memory limit usage of monitored process.\n"
+		"  --output-attr=obey|ignore\n"
+		"                  Obey or ignore output=\"*\" attributes on node tags.\n"
+		"                  Default is to ignore.\n"
 		"\n"
 		"rosmon also obeys some environment variables:\n"
 		"  ROSMON_COLOR_MODE   Can be set to 'truecolor', '256colors', 'ansi'\n"
@@ -131,6 +134,7 @@ static const struct option OPTIONS[] = {
 	{"cpu-limit", required_argument, nullptr, 'c'},
 	{"memory-limit", required_argument, nullptr, 'm'},
 	{"diagnostics-prefix", required_argument, nullptr, 'p'},
+	{"output-attr", required_argument, nullptr, 'o'},
 	{nullptr, 0, nullptr, 0}
 };
 
@@ -155,6 +159,7 @@ int main(int argc, char** argv)
 	float cpuLimit = rosmon::launch::LaunchConfig::DEFAULT_CPU_LIMIT;
 	bool disableDiagnostics = false;
 	std::string diagnosticsPrefix;
+	rosmon::launch::LaunchConfig::OutputAttr outputAttrMode = rosmon::launch::LaunchConfig::OutputAttr::Ignore;
 
 	// Parse options
 	while(true)
@@ -242,6 +247,17 @@ int main(int argc, char** argv)
 				}
 				break;
 			}
+			case 'o':
+				if(optarg == std::string("obey"))
+					outputAttrMode = rosmon::launch::LaunchConfig::OutputAttr::Obey;
+				else if(optarg == std::string("ignore"))
+					outputAttrMode = rosmon::launch::LaunchConfig::OutputAttr::Ignore;
+				else
+				{
+					fmt::print(stderr, "Bad value for --output-attr argument: '{}'\n", optarg);
+					return 1;
+				}
+				break;
 			case 'p':
 				fmt::print(stderr, "Prefix : {}", optarg);
 				diagnosticsPrefix = std::string(optarg);
@@ -334,6 +350,7 @@ int main(int argc, char** argv)
 	config->setDefaultStopTimeout(stopTimeout);
 	config->setDefaultCPULimit(cpuLimit);
 	config->setDefaultMemoryLimit(memoryLimit);
+	config->setOutputAttrMode(outputAttrMode);
 
 	// Parse launch file arguments from command line
 	for(int i = firstArg; i < argc; ++i)

--- a/rosmon_core/src/monitor/node_monitor.h
+++ b/rosmon_core/src/monitor/node_monitor.h
@@ -173,6 +173,11 @@ public:
 	inline double stopTimeout() const
 	{ return m_launchNode->stopTimeout(); }
 
+	void setMuted(bool muted);
+
+	bool isMuted() const
+	{ return m_muted; }
+
 	/**
 	 * @brief Logging signal
 	 *
@@ -234,6 +239,8 @@ private:
 	bool m_processWorkingDirectoryCreated = false;
 
 	bool m_firstStart = true;
+
+	bool m_muted = false;
 };
 
 }

--- a/rosmon_core/src/ui.cpp
+++ b/rosmon_core/src/ui.cpp
@@ -201,7 +201,7 @@ void UI::drawStatusLine()
 			printKey("k", "stop");
 			printKey("d", "debug");
 
-			if(isMuted(selectedNode->name()))
+			if(selectedNode->isMuted())
 				printKey("u", "unmute");
 			else
 				printKey("m", "mute");
@@ -296,7 +296,7 @@ void UI::drawStatusLine()
 			if(m_selectedNode == -1)
 			{
 				// Print key with grey background
-				if(isMuted(node->name()))
+				if(node->isMuted())
 					m_style_nodeKeyMuted.use();
 				else
 					m_style_nodeKey.use();
@@ -392,9 +392,11 @@ void UI::drawStatusLine()
 
 void UI::log(const LogEvent& event)
 {
-	if(isMuted(event.source))
+	// Is this node muted? Muted events go into the log, but are not shown in
+	// the UI.
+	if(event.muted)
 		return;
-	
+
 	const std::string& clean = event.message;
 
 	auto it = m_nodeColorMap.find(event.source);
@@ -675,15 +677,34 @@ void UI::handleKey(int c)
 				node->launchDebugger();
 				break;
 			case 'm':
-				mute(node->name());
+				node->setMuted(true);
 				break;
 			case 'u':
-				unmute(node->name());
+				node->setMuted(false);
 				break;
 		}
 
 		m_selectedNode = -1;
 	}
+}
+
+bool UI::anyMuted() const
+{
+	return std::any_of(m_monitor->nodes().begin(), m_monitor->nodes().end(), [](const monitor::NodeMonitor::Ptr& n){
+		return n->isMuted();
+	});
+}
+
+void UI::muteAll()
+{
+	for(auto& n : m_monitor->nodes())
+		n->setMuted(true);
+}
+
+void UI::unmuteAll()
+{
+	for(auto& n : m_monitor->nodes())
+		n->setMuted(false);
 }
 
 }

--- a/rosmon_core/src/ui.h
+++ b/rosmon_core/src/ui.h
@@ -53,23 +53,11 @@ private:
 
 	void handleKey(int key);
 
-	inline bool anyMuted()
-	{ return !m_mutedSet.empty(); }
+	bool anyMuted() const;
 
-	inline bool isMuted(const std::string &s) 
-	{ return m_mutedSet.find(s) != m_mutedSet.end(); }
+	void muteAll();
 
-	inline void mute(const std::string &s)
-	{ m_mutedSet.insert(s); }
-
-	inline void unmute(const std::string &s)
-	{ m_mutedSet.erase(s); }
-
-	inline void muteAll()
-	{ for(auto& node : m_monitor->nodes()) m_mutedSet.insert(node->name()); }
-
-	inline void unmuteAll()
-	{ m_mutedSet.clear(); }
+	void unmuteAll();
 
 	monitor::Monitor* m_monitor;
 	FDWatcher::Ptr m_fdWatcher;
@@ -79,8 +67,6 @@ private:
 	int m_columns;
 	ros::WallTimer m_sizeTimer;
 	ros::WallTimer m_terminalCheckTimer;
-
-	std::unordered_set<std::string> m_mutedSet;
 
 	std::map<std::string, ChannelInfo> m_nodeColorMap;
 

--- a/rosmon_core/test/xml/test_node.cpp
+++ b/rosmon_core/test/xml/test_node.cpp
@@ -251,6 +251,69 @@ TEST_CASE("node remap", "[remap]")
 	CHECK(remappings.at("private2") == "local_target");
 }
 
+TEST_CASE("node output attr", "[output]")
+{
+	SECTION("ignore")
+	{
+		LaunchConfig config;
+		config.setOutputAttrMode(LaunchConfig::OutputAttr::Ignore);
+		config.parseString(R"EOF(
+			<launch>
+				<node name="test_node" pkg="rosmon_core" type="abort" output="log">
+				</node>
+			</launch>
+		)EOF");
+
+		auto node = getNode(config.nodes(), "test_node");
+		CHECK(!node->isMuted());
+	}
+
+	SECTION("obey")
+	{
+		LaunchConfig config;
+		config.setOutputAttrMode(LaunchConfig::OutputAttr::Obey);
+		config.parseString(R"EOF(
+			<launch>
+				<node name="test_node" pkg="rosmon_core" type="abort">
+				</node>
+			</launch>
+		)EOF");
+
+		auto node = getNode(config.nodes(), "test_node");
+		CHECK(node->isMuted());
+	}
+
+	SECTION("obey log")
+	{
+		LaunchConfig config;
+		config.setOutputAttrMode(LaunchConfig::OutputAttr::Obey);
+		config.parseString(R"EOF(
+			<launch>
+				<node name="test_node" pkg="rosmon_core" type="abort" output="log">
+				</node>
+			</launch>
+		)EOF");
+
+		auto node = getNode(config.nodes(), "test_node");
+		CHECK(node->isMuted());
+	}
+
+	SECTION("obey screen")
+	{
+		LaunchConfig config;
+		config.setOutputAttrMode(LaunchConfig::OutputAttr::Obey);
+		config.parseString(R"EOF(
+			<launch>
+				<node name="test_node" pkg="rosmon_core" type="abort" output="screen">
+				</node>
+			</launch>
+		)EOF");
+
+		auto node = getNode(config.nodes(), "test_node");
+		CHECK(!node->isMuted());
+	}
+}
+
 // rosmon extensions
 
 TEST_CASE("node enable-coredumps", "[node]")


### PR DESCRIPTION
This is a refactored version of #108. If `--output-attr=obey` is given on the command line, actually parse the `output="screen|log"` attributes and use them to initialize the muting system.

This also refactors the muting system by moving the mute state into the `NodeMonitor` instance. That way, we don't have to track separate "muted" sets.