### PR TITLE
Improved support for nodes with terminal UI

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -222,6 +222,10 @@ void LaunchConfig::parseTopLevelAttributes(TiXmlElement* element)
 	const char* windowTitle = element->Attribute("rosmon-window-title");
 	if(windowTitle)
 		m_windowTitle = windowTitle;
+
+	const char* disableUI = element->Attribute("rosmon-disable-ui");
+	if(disableUI)
+		m_disableUI = m_rootContext.parseBool(disableUI, element->Row());
 }
 
 void LaunchConfig::parse(TiXmlElement* element, ParseContext* ctx, bool onlyArguments)

--- a/rosmon_core/src/launch/launch_config.h
+++ b/rosmon_core/src/launch/launch_config.h
@@ -201,6 +201,9 @@ public:
 	{ return m_windowTitle; }
 
 	std::string generateAnonHash();
+
+	bool disableUI() const
+	{ return m_disableUI; }
 private:
 	enum ParamContext
 	{
@@ -251,6 +254,8 @@ private:
 	double m_defaultCPULimit{DEFAULT_CPU_LIMIT};
 
 	OutputAttr m_outputAttrMode{OutputAttr::Ignore};
+
+	bool m_disableUI = false;
 };
 
 }

--- a/rosmon_core/src/main.cpp
+++ b/rosmon_core/src/main.cpp
@@ -105,14 +105,10 @@ void handleSignal(int)
 
 void logToStdout(const rosmon::LogEvent& event)
 {
-	std::string clean = event.message;
-	unsigned int len = clean.length();
-	while(len != 0 && (clean[len-1] == '\n' || clean[len-1] == '\r'))
-		len--;
+	std::cout << event.message;
 
-	clean.resize(len);
-
-	fmt::print("{:>20}: {}\n", event.source, clean);
+	if(!event.message.empty() && event.message.back() != '\n')
+		std::cout << '\n';
 
 	if(g_flushStdout)
 		fflush(stdout);

--- a/rosmon_core/src/main.cpp
+++ b/rosmon_core/src/main.cpp
@@ -394,6 +394,9 @@ int main(int argc, char** argv)
 			break;
 	}
 
+	if(config->disableUI())
+		enableUI = false;
+
 	// Initialize the ROS node.
 	{
 		uint32_t init_options = ros::init_options::NoSigintHandler;


### PR DESCRIPTION
For nodes that have their own terminal UI, rosmon should not interfere with that. We already had the `--disable-ui` flag for that, but this PR fixes some bugs and also allows to set this flag from the launch file.