### PR TITLE
Handle empty yaml file

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -914,6 +914,11 @@ void LaunchConfig::loadYAMLParams(const ParseContext& ctx, const YAML::Node& n, 
 			m_paramJobs.erase(prefix);
 			break;
 		}
+		case YAML::NodeType::Null:
+		{
+			// Nothing to do, empty node
+			break;
+		}
 		default:
 		{
 			throw ctx.error("invalid yaml node type");


### PR DESCRIPTION
`rosmon` has a different behavior compared to `roslaunch` in case of loading an empty yaml file.

I created a minimal example [here](https://github.com/marco-tranzatto/launch_file_examples/tree/master/rosmon_empty_yaml_issue).
The launch file "main.launch" contains a simple node that loads parameters from two different yaml files. The first file contains one parameters whereas the second one does not contain any "yaml node" to load. 

If the user executes
```
roslaunch rosmon_empty_yaml_issue main.launch
```
Then the launch succeeds. On the other hand, if the user executes
```
mon launch rosmon_empty_yaml_issue main.launch
```

Then the following error is reported:
```
Could not load launch file: /home/marcot/temp_ws/src/launch_file_examples/rosmon_empty_yaml_issue/launch/main.launch:10: error while parsing rosparam input file /home/marcot/temp_ws/src/launch_file_examples/rosmon_empty_yaml_issue/config/empty_file.yaml: /home/marcot/temp_ws/src/launch_file_examples/rosmon_empty_yaml_issue/launch/main.launch:10: invalid yaml node type
```

The problem originates on how the type of a yaml node is handled in "launch_config.cpp": `Null` type is caught by the `default` section of the switch and throws an error, even though there is not clear reason (in my eyes) to go for this harsh exit.

This PR should fix this minor issue by simply not throwing an exception in case of "null" yaml node. 

@xqms 