### PR TITLE
rosmon_core: Add YAML merge key parsing functionality.

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -899,9 +899,21 @@ void LaunchConfig::loadYAMLParams(const ParseContext& ctx, const YAML::Node& n, 
 	{
 		case YAML::NodeType::Map:
 		{
+			// Pass 1:
 			for(YAML::const_iterator it = n.begin(); it != n.end(); ++it)
 			{
-				loadYAMLParams(ctx, it->second, prefix + "/" + it->first.as<std::string>());
+				if (it->first.as<std::string>() == "<<")
+				{
+					loadYAMLParams(ctx, it->second, prefix);
+				}
+			}
+			// Pass 2:
+			for(YAML::const_iterator it = n.begin(); it != n.end(); ++it)
+			{
+				if (it->first.as<std::string>() != "<<")
+				{
+					loadYAMLParams(ctx, it->second, prefix + "/" + it->first.as<std::string>());
+				}											
 			}
 			break;
 		}

--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -899,22 +899,24 @@ void LaunchConfig::loadYAMLParams(const ParseContext& ctx, const YAML::Node& n, 
 	{
 		case YAML::NodeType::Map:
 		{
-			// Pass 1:
+			// Pass 1: Load any anchor references
 			for(YAML::const_iterator it = n.begin(); it != n.end(); ++it)
 			{
-				if (it->first.as<std::string>() == "<<")
+				if(it->first.as<std::string>() == "<<")
 				{
 					loadYAMLParams(ctx, it->second, prefix);
 				}
 			}
-			// Pass 2:
+
+			// Pass 2: Everything else.
 			for(YAML::const_iterator it = n.begin(); it != n.end(); ++it)
 			{
-				if (it->first.as<std::string>() != "<<")
+				if(it->first.as<std::string>() != "<<")
 				{
 					loadYAMLParams(ctx, it->second, prefix + "/" + it->first.as<std::string>());
-				}											
+				}
 			}
+
 			break;
 		}
 		case YAML::NodeType::Sequence:

--- a/rosmon_core/test/xml/test_rosparam.cpp
+++ b/rosmon_core/test/xml/test_rosparam.cpp
@@ -169,3 +169,90 @@ test_ns:
 	double param4 = getTypedParam<double>(params, "/test_ns/param4", XmlRpc::XmlRpcValue::TypeDouble);
 	CHECK(param4 == Approx(3.14169));
 }
+
+TEST_CASE("merge keys", "[rosparam]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+<rosparam>
+common: &amp;common
+  param1: true
+  param2: 5.0
+  param3: hello
+commonclass: &amp;commonclass
+  testclass:
+    &lt;&lt;: *common
+    testparam: 140
+class1:
+  &lt;&lt;: *common
+  param4: 514
+class2:
+  param1: false
+  &lt;&lt;: *common
+class3:
+  &lt;&lt;: *common
+  param1: false
+class4:
+  &lt;&lt;: *common
+  param1: 5
+  param2: test
+  param3: 0.1
+class5:
+  &lt;&lt;: *commonclass
+  param4: sub
+class6:
+  &lt;&lt;: *commonclass
+  testclass:
+    param2: 10.0
+</rosparam>
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	CAPTURE(config.parameters());
+
+	auto& params = config.parameters();
+
+	// Class 1 test simple addition
+	std::string class_ns = "/class1";
+	checkTypedParam<bool>(params, class_ns + "/param1", XmlRpc::XmlRpcValue::TypeBoolean, true);
+	checkTypedParam<double>(params, class_ns + "/param2", XmlRpc::XmlRpcValue::TypeDouble, 5.0);
+	checkTypedParam<std::string>(params, class_ns + "/param3", XmlRpc::XmlRpcValue::TypeString, "hello");
+	checkTypedParam<int>(params, class_ns + "/param4", XmlRpc::XmlRpcValue::TypeInt, 514);
+
+	// Class 2 test override pre-assigned
+	class_ns = "/class2";
+	checkTypedParam<bool>(params, class_ns + "/param1", XmlRpc::XmlRpcValue::TypeBoolean, false);
+	checkTypedParam<double>(params, class_ns + "/param2", XmlRpc::XmlRpcValue::TypeDouble, 5.0);
+	checkTypedParam<std::string>(params, class_ns + "/param3", XmlRpc::XmlRpcValue::TypeString, "hello");
+
+	// Class 3 test override post-assigned
+	class_ns = "/class3";
+	checkTypedParam<bool>(params, class_ns + "/param1", XmlRpc::XmlRpcValue::TypeBoolean, false);
+	checkTypedParam<double>(params, class_ns + "/param2", XmlRpc::XmlRpcValue::TypeDouble, 5.0);
+	checkTypedParam<std::string>(params, class_ns + "/param3", XmlRpc::XmlRpcValue::TypeString, "hello");
+
+	// Class 4 test typechange overrides
+	class_ns = "/class4";
+	checkTypedParam<int>(params, class_ns + "/param1", XmlRpc::XmlRpcValue::TypeInt, 5);
+	checkTypedParam<std::string>(params, class_ns + "/param2", XmlRpc::XmlRpcValue::TypeString, "test");
+	checkTypedParam<double>(params, class_ns + "/param3", XmlRpc::XmlRpcValue::TypeDouble, 0.1);
+
+	// Class 5 test nested merge
+	class_ns = "/class5";
+	checkTypedParam<bool>(params, class_ns + "/testclass/param1", XmlRpc::XmlRpcValue::TypeBoolean, true);
+	checkTypedParam<double>(params, class_ns + "/testclass/param2", XmlRpc::XmlRpcValue::TypeDouble, 5.0);
+	checkTypedParam<std::string>(params, class_ns + "/testclass/param3", XmlRpc::XmlRpcValue::TypeString, "hello");
+	checkTypedParam<int>(params, class_ns + "/testclass/testparam", XmlRpc::XmlRpcValue::TypeInt, 140);
+	checkTypedParam<std::string>(params, class_ns + "/param4", XmlRpc::XmlRpcValue::TypeString, "sub");
+
+	// Class 6 test override on nested merge
+	class_ns = "/class6";
+	checkTypedParam<bool>(params, class_ns + "/testclass/param1", XmlRpc::XmlRpcValue::TypeBoolean, true);
+	checkTypedParam<double>(params, class_ns + "/testclass/param2", XmlRpc::XmlRpcValue::TypeDouble, 10.0);
+	checkTypedParam<std::string>(params, class_ns + "/testclass/param3", XmlRpc::XmlRpcValue::TypeString, "hello");
+	checkTypedParam<int>(params, class_ns + "/testclass/testparam", XmlRpc::XmlRpcValue::TypeInt, 140);
+
+}


### PR DESCRIPTION
Addresses #106.

Hello again @xqms. Over the past year I made a number of improvements and fixes to rosmon in one of my projects. I'll be rolling out these changes into PR's over the next few days.

This is a patch that enables YAML merge key functionality and somewhat addresses #106. While I am aware that `yaml-cpp` is technically the responsible party, their MR has still not yet been resolved, and `YAML` proper is partially to blame. Given that we really needed this, I made this patch for my team's purposes and successfully saved a lot of time our our end being able to use YAML anchors.

Here is an example `yaml` file I ran this patch over with success:
```yaml
common: &common
    flux_a: 2.4
    type_f: "vv_2de119"
    stable: true
    u_val: 3.0e-5

base_params: &base_params
    class1:
        x_var: 3.4
        y_var: 1.3
        z_var: 0.0
        w_var: 44.5
    class2:
        x_var: 3.3
        y_var: 1.3
        z_var: 0.09
        w_var: 35.3
    <<: *common

node5:
    <<: *base_params
    class1:
        y_var: 2.0
    id: 5
    

node4:
    <<: *base_params
    class2:
        y_var: 2.0
    id: 4
```

I cross-compared the functionality of this and `roslaunch` and there is only one major difference in implementation (and I would argue this implementation is superior).

## rosmon result
This is the output from `rosparam dump` with the patched `rosmon`:
```yaml
base_params:
  class1: {w_var: 44.5, x_var: 3.4, y_var: 1.3, z_var: 0.0}
  class2: {w_var: 35.3, x_var: 3.3, y_var: 1.3, z_var: 0.09}
  flux_a: 2.4
  stable: true
  type_f: vv_2de119
  u_val: 3.0e-05
common: {flux_a: 2.4, stable: true, type_f: vv_2de119, u_val: 3.0e-05}
node4:
  class1: {w_var: 44.5, x_var: 3.4, y_var: 1.3, z_var: 0.0}
  class2: {w_var: 35.3, x_var: 3.3, y_var: 2.0, z_var: 0.09}
  flux_a: 2.4
  id: 4
  stable: true
  type_f: vv_2de119
  u_val: 3.0e-05
node5:
  class1: {w_var: 44.5, x_var: 3.4, y_var: 2.0, z_var: 0.0}
  class2: {w_var: 35.3, x_var: 3.3, y_var: 1.3, z_var: 0.09}
  flux_a: 2.4
  id: 5
  stable: true
  type_f: vv_2de119
  u_val: 3.0e-05
```
## roslaunch result
This is the output from`rosparam dump` with the standard `roslaunch` on melodic:
```yaml
base_params:
  class1: {w_var: 44.5, x_var: 3.4, y_var: 1.3, z_var: 0.0}
  class2: {w_var: 35.3, x_var: 3.3, y_var: 1.3, z_var: 0.09}
  flux_a: 2.4
  stable: true
  type_f: vv_2de119
  u_val: 3.0e-05
common: {flux_a: 2.4, stable: true, type_f: vv_2de119, u_val: 3.0e-05}
node4:
  class1: {w_var: 44.5, x_var: 3.4, y_var: 1.3, z_var: 0.0}
  class2: {y_var: 2.0}
  flux_a: 2.4
  id: 4
  stable: true
  type_f: vv_2de119
  u_val: 3.0e-05
node5:
  class1: {y_var: 2.0}
  class2: {w_var: 35.3, x_var: 3.3, y_var: 1.3, z_var: 0.09}
  flux_a: 2.4
  id: 5
  stable: true
  type_f: vv_2de119
  u_val: 3.0e-05
```
## Difference
You'll notice that the override of
```yaml
    class2:
        y_var: 2.0
```
of a nested yaml struct in roslaunch completely replaces the structure, whereas in `rosmon`, it simply replaces the corresponding value in the struct with the new value, leaving all other values in place. I'd argue this is how this *aught* to be, but you can also make an argument that this 'doesn't align' with roslaunch, and therefore is 'unsatisfactory'. I'll leave this up to you.


Let me know your thoughts!