### PR TITLE
rosmon_core: Adding fix for rosparam parsing to equivilate with undocumented behavior of roslaunch

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -427,7 +427,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext& attr_ctx)
 		node->setRequired(true);
 	}
 
-	// First Pass
+	// We have to parse rosparam tags first, see #118
 	for(TiXmlNode* n = element->FirstChild(); n; n = n->NextSibling())
 	{
 		TiXmlElement* e = n->ToElement();
@@ -443,7 +443,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext& attr_ctx)
 			parseROSParam(e, ctx);
 	}
 
-	// Second Pass
+	// Now we can parse everything else.
 	for(TiXmlNode* n = element->FirstChild(); n; n = n->NextSibling())
 	{
 		TiXmlElement* e = n->ToElement();

--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -427,6 +427,23 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext& attr_ctx)
 		node->setRequired(true);
 	}
 
+	// First Pass
+	for(TiXmlNode* n = element->FirstChild(); n; n = n->NextSibling())
+	{
+		TiXmlElement* e = n->ToElement();
+		if(!e)
+			continue;
+
+		if(ctx.shouldSkip(e))
+			continue;
+
+		ctx.setCurrentElement(e);
+
+		if(e->ValueStr() == "rosparam")
+			parseROSParam(e, ctx);
+	}
+
+	// Second Pass
 	for(TiXmlNode* n = element->FirstChild(); n; n = n->NextSibling())
 	{
 		TiXmlElement* e = n->ToElement();
@@ -440,8 +457,6 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext& attr_ctx)
 
 		if(e->ValueStr() == "param")
 			parseParam(e, ctx, PARAM_IN_NODE);
-		else if(e->ValueStr() == "rosparam")
-			parseROSParam(e, ctx);
 		else if(e->ValueStr() == "remap")
 			parseRemap(e, ctx);
 		else if(e->ValueStr() == "env")


### PR DESCRIPTION
This was a really insidious and potentially controversial patch we needed to make to `rosmon` to handle some undocumented behavior of `roslaunch`.

The tl;dr is that `roslaunch` parses all `<rosparam>` tags before it parses all `<param>` tags. This is in contrast to what `rosmon` does:
```cpp
	for(TiXmlNode* n = element->FirstChild(); n; n = n->NextSibling())
	{
                 .
                 .
                 .
		if(e->ValueStr() == "param")
			parseParam(e, ctx, PARAM_IN_NODE);
		else if(e->ValueStr() == "rosparam")
			parseROSParam(e, ctx);
		else if(e->ValueStr() == "remap")
			parseRemap(e, ctx);
		else if(e->ValueStr() == "env")
        }
```

This manifested itself as a really annoying bug when we were working with [mavros](http://wiki.ros.org/mavros). Specifically [this launch file](https://github.com/mavlink/mavros/blob/master/mavros/launch/node.launch) of theirs made the above difference matter. 

We had setups running this file on roslaunch work with custom `param` inputs properly overriding the mavros frame_id namespaces. But when run on rosmon the custom `param` namespaces were not propagated, since in the above logic, the `param` fields got overridden by `rosparam` anyway. 

I believe I did attempt a patch of simply moving `rosparam` above `param` but this did not solve the problem since the for-loop would still loop around `params` before reaching `rosparam` tags

The solution isn't great but it matches how `roslaunch` works, and shouldn't affect existing users.