### PR TITLE
rosmon_core: Adding verbosity filter feature

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -483,18 +483,18 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext& attr_ctx)
 
 	if(m_outputAttrMode == OutputAttr::Obey)
 	{
-		node->setMuted(true); // output=log is default
+		node->setStdoutDisplayed(false); // output=log is default
+	}
 
-		if(output)
-		{
-			std::string outputStr = attr_ctx.evaluate(output);
-			if(outputStr == "screen")
-				node->setMuted(false);
-			else if(outputStr == "log")
-				node->setMuted(true);
-			else
-				throw ctx.error("Invalid output attribute value: '{}'", outputStr);
-		}
+	if(output)
+	{
+		std::string outputStr = attr_ctx.evaluate(output);
+		if(outputStr == "screen")
+			node->setStdoutDisplayed(true);
+		else if(outputStr == "log")
+			node->setStdoutDisplayed(false);
+		else
+			throw ctx.error("Invalid output attribute value: '{}'", outputStr);
 	}
 
 	node->setRemappings(ctx.remappings());

--- a/rosmon_core/src/launch/node.cpp
+++ b/rosmon_core/src/launch/node.cpp
@@ -42,6 +42,7 @@ Node::Node(std::string name, std::string package, std::string type)
  , m_memoryLimitByte(15e6)
  , m_cpuLimit(0.05)
  , m_muted(false)
+ , m_stdoutDisplayed(true)
 {
 	m_executable = PackageRegistry::getExecutable(m_package, m_type);
 }
@@ -159,6 +160,11 @@ void Node::setCPULimit(float cpuLimit)
 void Node::setMuted(bool muted)
 {
 	m_muted = muted;
+}
+
+void Node::setStdoutDisplayed(bool displayed)
+{
+	m_stdoutDisplayed = displayed;
 }
 
 }

--- a/rosmon_core/src/launch/node.h
+++ b/rosmon_core/src/launch/node.h
@@ -47,6 +47,7 @@ public:
 	void setCPULimit(float cpuLimit);
 
 	void setMuted(bool muted);
+	void setStdoutDisplayed(bool showStdout);
 
 	std::string name() const
 	{ return m_name; }
@@ -106,6 +107,9 @@ public:
 
 	bool isMuted() const
 	{ return m_muted; }
+
+	bool stdoutDisplayed() const
+	{ return m_stdoutDisplayed; }
 private:
 	std::string m_name;
 	std::string m_package;
@@ -139,6 +143,7 @@ private:
 	float m_cpuLimit;
 
 	bool m_muted;
+	bool m_stdoutDisplayed;
 };
 
 }

--- a/rosmon_core/src/log_event.h
+++ b/rosmon_core/src/log_event.h
@@ -24,6 +24,13 @@ public:
 		Error
 	};
 
+	enum class Channel
+	{
+		NotApplicable,
+		Stdout,
+		Stderr
+	};
+
 	LogEvent(std::string source, std::string message, Type type = Type::Raw)
 	 : source{std::move(source)}, message{std::move(message)}, type{type}
 	{}
@@ -32,6 +39,8 @@ public:
 	std::string message;
 	Type type;
 	bool muted = false;
+	Channel channel = Channel::NotApplicable;
+	bool showStdout = true;
 };
 
 }

--- a/rosmon_core/src/monitor/node_monitor.h
+++ b/rosmon_core/src/monitor/node_monitor.h
@@ -198,6 +198,7 @@ private:
 	std::vector<std::string> composeCommand() const;
 
 	void communicate();
+	void communicateStderr();
 
 	template<typename... Args>
 	void log(const char* format, Args&& ... args);
@@ -213,9 +214,11 @@ private:
 	FDWatcher::Ptr m_fdWatcher;
 
 	boost::circular_buffer<char> m_rxBuffer;
+	boost::circular_buffer<char> m_stderrBuffer;
 
 	int m_pid = -1;
 	int m_fd = -1;
+	int m_stderrFD = -1;
 	int m_exitCode;
 
 	ros::WallTimer m_stopCheckTimer;

--- a/rosmon_core/src/monitor/shim.cpp
+++ b/rosmon_core/src/monitor/shim.cpp
@@ -23,6 +23,7 @@ static const struct option OPTIONS[] = {
 	{"coredump-relative", required_argument, nullptr, 'C'},
 	{"tty", required_argument, nullptr, 't'},
 	{"run", required_argument, nullptr, 'r'},
+	{"stderr", required_argument, nullptr, 's'},
 
 	{nullptr, 0, nullptr, 0}
 };
@@ -41,6 +42,8 @@ Options:
   --coredump               Enable coredump collection
   --coredump-relative=DIR  Coredumps should go to DIR
   --run <executable>       All arguments after this one are passed on
+  --tty TTY                TTY fd for stdout
+  --stderr FD              file descriptor for stderr
 )EOS");
 }
 
@@ -53,6 +56,7 @@ int main(int argc, char** argv)
 	int nodeOptionsBegin = -1;
 
 	int tty = -1;
+	int stderr_fd = -1;
 
 	while(true)
 	{
@@ -97,6 +101,9 @@ int main(int argc, char** argv)
 				nodeExecutable = optarg;
 				nodeOptionsBegin = optind;
 				break;
+			case 's':
+				stderr_fd = atoi(optarg);
+				break;
 		}
 
 		if(nodeExecutable)
@@ -109,9 +116,18 @@ int main(int argc, char** argv)
 	if(tty < 0)
 		throw std::invalid_argument("Need --tty option");
 
+	if(stderr_fd < 0)
+		throw std::invalid_argument("Need --stderr option");
+
 	if(login_tty(tty) != 0)
 	{
 		perror("Could not call login_tty()");
+		std::abort();
+	}
+
+	if(dup2(stderr_fd, STDERR_FILENO) < 0)
+	{
+		perror("Could not call dup2() for stderr");
 		std::abort();
 	}
 

--- a/rosmon_core/src/ui.cpp
+++ b/rosmon_core/src/ui.cpp
@@ -397,6 +397,10 @@ void UI::log(const LogEvent& event)
 	if(event.muted)
 		return;
 
+	// Are we supposed to show stdout?
+	if(event.channel == LogEvent::Channel::Stdout && !event.showStdout)
+		return;
+
 	const std::string& clean = event.message;
 
 	auto it = m_nodeColorMap.find(event.source);

--- a/rosmon_core/src/ui.cpp
+++ b/rosmon_core/src/ui.cpp
@@ -209,9 +209,19 @@ void UI::drawStatusLine()
 		else
 		{
 			printKey("A-Z", "Node actions");
+			printKey("F8", "Toggle WARN+ only");
 			printKey("F9", "Mute all");
 			printKey("F10", "Unmute all");
 			printKey("/", "Node search");
+
+			if(stderrOnly())
+			{
+				print("      ");
+				m_term.setSimpleForeground(Terminal::Black);
+				m_term.setSimpleBackground(Terminal::Magenta);
+				print("! WARN+ output only !");
+				m_style_bar.use();
+			}
 
 			if(anyMuted())
 			{
@@ -398,7 +408,7 @@ void UI::log(const LogEvent& event)
 		return;
 
 	// Are we supposed to show stdout?
-	if(event.channel == LogEvent::Channel::Stdout && !event.showStdout)
+	if(event.channel == LogEvent::Channel::Stdout && (!event.showStdout || stderrOnly()))
 		return;
 
 	const std::string& clean = event.message;
@@ -653,6 +663,13 @@ void UI::handleKey(int c)
 			return;
 		}
 
+		// Check for Stderr Only Toggle
+		if(c == Terminal::SK_F8)
+		{
+			toggleStderrOnly();
+			return;
+		}
+
 		// Search
 		if(c == '/')
 		{
@@ -725,6 +742,16 @@ void UI::unmuteAll()
 void UI::scheduleUpdate()
 {
 	m_refresh_required = true;
+}
+
+bool UI::stderrOnly()
+{
+	return m_stderr_only;
+}
+
+void UI::toggleStderrOnly()
+{
+	m_stderr_only = !m_stderr_only;
 }
 
 }

--- a/rosmon_core/src/ui.h
+++ b/rosmon_core/src/ui.h
@@ -59,11 +59,16 @@ private:
 
 	void unmuteAll();
 
+	bool stderrOnly();
+
+	void toggleStderrOnly();
+
 	void scheduleUpdate();
 
 	monitor::Monitor* m_monitor;
 	FDWatcher::Ptr m_fdWatcher;
 	bool m_refresh_required = true;
+	bool m_stderr_only = false;
 
 	Terminal m_term;
 

--- a/rosmon_core/test/xml/test_node.cpp
+++ b/rosmon_core/test/xml/test_node.cpp
@@ -265,7 +265,7 @@ TEST_CASE("node output attr", "[output]")
 		)EOF");
 
 		auto node = getNode(config.nodes(), "test_node");
-		CHECK(!node->isMuted());
+		CHECK(!node->stdoutDisplayed());
 	}
 
 	SECTION("obey")
@@ -280,7 +280,7 @@ TEST_CASE("node output attr", "[output]")
 		)EOF");
 
 		auto node = getNode(config.nodes(), "test_node");
-		CHECK(node->isMuted());
+		CHECK(!node->stdoutDisplayed());
 	}
 
 	SECTION("obey log")
@@ -295,7 +295,7 @@ TEST_CASE("node output attr", "[output]")
 		)EOF");
 
 		auto node = getNode(config.nodes(), "test_node");
-		CHECK(node->isMuted());
+		CHECK(!node->stdoutDisplayed());
 	}
 
 	SECTION("obey screen")
@@ -310,7 +310,7 @@ TEST_CASE("node output attr", "[output]")
 		)EOF");
 
 		auto node = getNode(config.nodes(), "test_node");
-		CHECK(!node->isMuted());
+		CHECK(node->stdoutDisplayed());
 	}
 }
 


### PR DESCRIPTION
Here's yet another filter I added to `rosmon`. This was a bit tricky to get proper, but the tl;dr is that this uses the `fgColor` value to determine the log level. The reason why I went this route was a couple of reasons:
- We already get `fgColor` and it's simple to implement.
- When I checked the raw strings, there are actually subtle control character differences between C++ and Python ROS console output for the same log levels, which makes any non-color based solution inherently more complex.

I added F6, F7, and F8 as keys to select the verbosity level. Currently I just have it set to display levels 1, 2, and 3, but if you want I can change it to show 'Low, Med, High' or some effect. 
- 1 : Only `WARN`+ messages printed 
- 2 : Only `INFO`+ messages printed
- 3 : `DEBUG`+ messages printed (all)

Also as a consequence of this, this inevitably adds to the already increasing size of the control bar. Something I thought of was to make the bar 'togglable', like with F1 or some key. This way we could have the default bar be just status messages (like Mute and Verbosity level) and if the user wants to see the controls, they can press `F1` and a multi-level bar could appear with all options outlined.

If we want to do that that'll have to be a separate PR (I haven't written code for that, just my musings).