### PR TITLE
rosmon_core: ui: UI DrawStatus optimized to only refresh on events.

### DIFF
--- a/rosmon_core/src/ui.h
+++ b/rosmon_core/src/ui.h
@@ -59,8 +59,11 @@ private:
 
 	void unmuteAll();
 
+	void scheduleUpdate();
+
 	monitor::Monitor* m_monitor;
 	FDWatcher::Ptr m_fdWatcher;
+	bool m_refresh_required = true;
 
 	Terminal m_term;
 


### PR DESCRIPTION
This was an important update to significantly reduce the 'idle' bandwidth on wireless low-bandwidth networks. This improves usability over ssh/mosh to remote nodes.

The way rosmon's update function seems to work is that it's called at a nominal rate of 10Hz, regardless of what's going on in the console screen. This was readily apparent when using `mosh` paired with Wireshark, where observing ~60 nodes all muted (so no new information is being printed), rosmon consumed ~50 kbps on average. All of this was from re-rendering the multitude of node status bars at a nominal rate of 10Hz.

So what this patch does is it gates the actual updating against a boolean that's set to true only on user key events and logging events. The same scenario described above with this patch effectively makes the 'idle' bandwidth 0 kbps. This patch still maintains the responsiveness of the original and, if you press a lot of keys, you will obviously trigger the draw function a lot. The goal of this patch is to only draw or update when something needs to be drawn. 