### PR TITLE
rosmon_core: depend on python2/3 conditioned on ROS_PYTHON_VERSION

### DIFF
--- a/rosmon_core/package.xml
+++ b/rosmon_core/package.xml
@@ -1,4 +1,4 @@
-<package format="2">
+<package format="3">
 	<name>rosmon_core</name>
 	<description>
 		Node launcher and monitor for ROS. rosmon is a replacement
@@ -25,9 +25,11 @@
 	<depend>yaml-cpp</depend>
 	<depend>diagnostic_msgs</depend>
 	
-	<build_depend>python</build_depend>
+	<build_depend condition="$ROS_PYTHON_VERSION == 2">python</build_depend>
+	<build_depend condition="$ROS_PYTHON_VERSION == 3">python3</build_depend>
 
-	<test_depend>python-rospkg</test_depend>
+	<test_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</test_depend>
+	<test_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</test_depend>
 	<test_depend>rostest</test_depend>
 	<test_depend>catch_ros</test_depend>
 </package>


### PR DESCRIPTION
Necessary for ROS Noetic, where Python 2 is not available anymore. See #120.