### PR TITLE
Support certain attributes on all scopes

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -88,6 +88,11 @@ void ParseContext::parseScopeAttributes(TiXmlElement* e, ParseContext& attr_ctx)
 
 		m_cpuLimit = cpuLimitPct;
 	}
+
+	if(const char* coredumpsEnabled = e->Attribute("enable-coredumps"))
+	{
+		m_coredumpsEnabled = attr_ctx.parseBool(coredumpsEnabled, e->Row());
+	}
 }
 
 std::string ParseContext::evaluate(const std::string& tpl, bool simplifyWhitespace)
@@ -351,7 +356,6 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext& attr_ctx)
 	const char* respawnDelay = element->Attribute("respawn_delay");
 	const char* required = element->Attribute("required");
 	const char* launchPrefix = element->Attribute("launch-prefix");
-	const char* coredumpsEnabled = element->Attribute("enable-coredumps");
 	const char* cwd = element->Attribute("cwd");
 	const char* clearParams = element->Attribute("clear_params");
 	const char* output = element->Attribute("output");
@@ -394,6 +398,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext& attr_ctx)
 	node->setStopTimeout(ctx.stopTimeout());
 	node->setMemoryLimit(ctx.memoryLimit());
 	node->setCPULimit(ctx.cpuLimit());
+	node->setCoredumpsEnabled(ctx.coredumpsEnabled());
 
 	if(args)
 		node->addExtraArguments(ctx.evaluate(args));
@@ -469,9 +474,6 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext& attr_ctx)
 
 	if(launchPrefix)
 		node->setLaunchPrefix(attr_ctx.evaluate(launchPrefix));
-
-	if(coredumpsEnabled)
-		node->setCoredumpsEnabled(attr_ctx.parseBool(coredumpsEnabled, element->Row()));
 
 	if(cwd)
 		node->setWorkingDirectory(attr_ctx.evaluate(cwd));

--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -281,6 +281,8 @@ void LaunchConfig::parseTopLevelAttributes(TiXmlElement* element)
 
 void LaunchConfig::parse(TiXmlElement* element, ParseContext* ctx, bool onlyArguments)
 {
+	ctx->parseScopeAttributes(element, *ctx);
+
 	// First pass: Parse arguments
 	for(TiXmlNode* n = element->FirstChild(); n; n = n->NextSibling())
 	{
@@ -320,12 +322,12 @@ void LaunchConfig::parse(TiXmlElement* element, ParseContext* ctx, bool onlyArgu
 			parseROSParam(e, *ctx);
 		else if(e->ValueStr() == "group")
 		{
-			const char* ns = e->Attribute("ns");
-
 			ParseContext cctx = *ctx;
 
-			if(ns)
+			if(const char* ns = e->Attribute("ns"))
 				cctx = cctx.enterScope(ctx->evaluate(ns));
+
+			cctx.parseScopeAttributes(e, *ctx);
 
 			parse(e, &cctx);
 		}
@@ -974,6 +976,7 @@ void LaunchConfig::parseInclude(TiXmlElement* element, ParseContext ctx)
 		childCtx = childCtx.enterScope(ctx.evaluate(ns));
 
 	// Parse any arguments
+	childCtx.parseScopeAttributes(element, ctx);
 
 	// If pass_all_args is not set, delete the current arguments.
 	if(!passAllArgs || !ctx.parseBool(passAllArgs, element->Row()))

--- a/rosmon_core/src/launch/launch_config.h
+++ b/rosmon_core/src/launch/launch_config.h
@@ -150,6 +150,11 @@ public:
 	void setStopTimeout(float timeout)
 	{ m_stopTimeout = timeout; }
 
+	bool coredumpsEnabled() const
+	{ return m_coredumpsEnabled; }
+	void setCoredumpsEnabled(bool enabled)
+	{ m_coredumpsEnabled = enabled; }
+
 private:
 	LaunchConfig* m_config;
 
@@ -164,6 +169,7 @@ private:
 	float m_cpuLimit = DEFAULT_CPU_LIMIT;
 	uint64_t m_memoryLimit = DEFAULT_MEMORY_LIMIT;
 	float m_stopTimeout = DEFAULT_STOP_TIMEOUT;
+	bool m_coredumpsEnabled = true;
 };
 
 class LaunchConfig

--- a/rosmon_core/src/launch/launch_config.h
+++ b/rosmon_core/src/launch/launch_config.h
@@ -25,6 +25,10 @@ namespace launch
 
 class LaunchConfig;
 
+constexpr float DEFAULT_CPU_LIMIT = 0.9f;
+constexpr uint64_t DEFAULT_MEMORY_LIMIT = 500*1024*1024;
+constexpr float DEFAULT_STOP_TIMEOUT = 5.0f;
+
 class ParseException : public std::exception
 {
 public:
@@ -78,6 +82,7 @@ public:
 	}
 
 	ParseContext enterScope(const std::string& prefix);
+	void parseScopeAttributes(TiXmlElement* e, ParseContext& attr_ctx);
 
 	std::string evaluate(const std::string& tpl, bool simplifyWhitespace = true);
 
@@ -128,6 +133,23 @@ public:
 
 	template<typename... Args>
 	void warning(const char* fmt, const Args& ... args) const;
+
+
+	float cpuLimit() const
+	{ return m_cpuLimit; }
+	void setCPULimit(float limit)
+	{ m_cpuLimit = limit; }
+
+	uint64_t memoryLimit() const
+	{ return m_memoryLimit; }
+	void setMemoryLimit(uint64_t limit)
+	{ m_memoryLimit = limit; }
+
+	float stopTimeout() const
+	{ return m_stopTimeout; }
+	void setStopTimeout(float timeout)
+	{ m_stopTimeout = timeout; }
+
 private:
 	LaunchConfig* m_config;
 
@@ -138,6 +160,10 @@ private:
 	std::map<std::string, std::string> m_environment;
 	std::map<std::string, std::string> m_remappings;
 	std::map<std::string, std::string> m_anonNames;
+
+	float m_cpuLimit = DEFAULT_CPU_LIMIT;
+	uint64_t m_memoryLimit = DEFAULT_MEMORY_LIMIT;
+	float m_stopTimeout = DEFAULT_STOP_TIMEOUT;
 };
 
 class LaunchConfig
@@ -145,10 +171,6 @@ class LaunchConfig
 public:
 	typedef std::shared_ptr<LaunchConfig> Ptr;
 	typedef std::shared_ptr<const LaunchConfig> ConstPtr;
-
-	constexpr static float DEFAULT_CPU_LIMIT = 0.9f;
-	constexpr static uint64_t DEFAULT_MEMORY_LIMIT = 500*1024*1024;
-	constexpr static float DEFAULT_STOP_TIMEOUT = 5.0f;
 
 	LaunchConfig();
 
@@ -240,10 +262,6 @@ private:
 	std::string m_rosmonNodeName;
 
 	std::string m_windowTitle;
-
-	double m_defaultStopTimeout{DEFAULT_STOP_TIMEOUT};
-	uint64_t m_defaultMemoryLimit{DEFAULT_MEMORY_LIMIT};
-	double m_defaultCPULimit{DEFAULT_CPU_LIMIT};
 
 	OutputAttr m_outputAttrMode{OutputAttr::Ignore};
 

--- a/rosmon_core/src/main.cpp
+++ b/rosmon_core/src/main.cpp
@@ -150,9 +150,9 @@ int main(int argc, char** argv)
 	bool enableUI = true;
 	bool flushLog = false;
 	bool startNodes = true;
-	double stopTimeout = rosmon::launch::LaunchConfig::DEFAULT_STOP_TIMEOUT;
-	uint64_t memoryLimit = rosmon::launch::LaunchConfig::DEFAULT_MEMORY_LIMIT;
-	float cpuLimit = rosmon::launch::LaunchConfig::DEFAULT_CPU_LIMIT;
+	double stopTimeout = rosmon::launch::DEFAULT_STOP_TIMEOUT;
+	uint64_t memoryLimit = rosmon::launch::DEFAULT_MEMORY_LIMIT;
+	float cpuLimit = rosmon::launch::DEFAULT_CPU_LIMIT;
 	bool disableDiagnostics = false;
 	std::string diagnosticsPrefix;
 	rosmon::launch::LaunchConfig::OutputAttr outputAttrMode = rosmon::launch::LaunchConfig::OutputAttr::Ignore;

--- a/rosmon_core/test/basic.py
+++ b/rosmon_core/test/basic.py
@@ -46,7 +46,7 @@ class BasicTest(unittest.TestCase):
 		except rospy.ROSException:
 			self.fail('Did not get state msg on /rosmon_uut/state' + repr(rospy.client.get_published_topics()))
 
-		self.assertEqual(len(state.nodes), 3)
+		self.assertEqual(len(state.nodes), 4)
 
 		test1 = [ n for n in state.nodes if n.name == 'test1' ]
 		self.assertEqual(len(test1), 1)

--- a/rosmon_core/test/basic_sub.launch
+++ b/rosmon_core/test/basic_sub.launch
@@ -2,4 +2,6 @@
 	<arg name="test_argument" default="321" />
 
 	<param name="test_argument" value="$(arg test_argument)" />
+
+	<node pkg="rosmon_core" type="abort" name="test_node" />
 </launch>

--- a/rosmon_core/test/xml/test_node.cpp
+++ b/rosmon_core/test/xml/test_node.cpp
@@ -342,6 +342,10 @@ TEST_CASE("node memory/cpu limit", "[node]")
 		<launch>
 			<node name="test_node_default" pkg="rosmon_core" type="abort" />
 			<node name="test_node_custom" pkg="rosmon_core" type="abort" rosmon-memory-limit="200" rosmon-cpu-limit="0.2" />
+
+			<group rosmon-memory-limit="100">
+				<node name="test_node_grouped" pkg="rosmon_core" type="abort" />
+			</group>
 		</launch>
 	)EOF");
 
@@ -357,4 +361,7 @@ TEST_CASE("node memory/cpu limit", "[node]")
 	auto custom = getNode(nodes, "test_node_custom");
 	CHECK(custom->memoryLimitByte() == 200);
 	CHECK(custom->cpuLimit() == Approx(0.2f));
+
+	auto grouped = getNode(nodes, "test_node_grouped");
+	CHECK(grouped->memoryLimitByte() == 100);
 }

--- a/rosmon_core/test/xml/test_node.cpp
+++ b/rosmon_core/test/xml/test_node.cpp
@@ -334,3 +334,27 @@ TEST_CASE("node enable-coredumps", "[node]")
 	CHECK(getNode(nodes, "test_node_on")->coredumpsEnabled() == true);
 	CHECK(getNode(nodes, "test_node_off")->coredumpsEnabled() == false);
 }
+
+TEST_CASE("node memory/cpu limit", "[node]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+			<node name="test_node_default" pkg="rosmon_core" type="abort" />
+			<node name="test_node_custom" pkg="rosmon_core" type="abort" rosmon-memory-limit="200" rosmon-cpu-limit="0.2" />
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	auto nodes = config.nodes();
+	CAPTURE(nodes);
+
+	auto def = getNode(nodes, "test_node_default");
+	CHECK(def->memoryLimitByte() == rosmon::launch::DEFAULT_MEMORY_LIMIT);
+	CHECK(def->cpuLimit() == Approx(rosmon::launch::DEFAULT_CPU_LIMIT));
+
+	auto custom = getNode(nodes, "test_node_custom");
+	CHECK(custom->memoryLimitByte() == 200);
+	CHECK(custom->cpuLimit() == Approx(0.2f));
+}

--- a/rosmon_core/test/xml/test_node.cpp
+++ b/rosmon_core/test/xml/test_node.cpp
@@ -343,7 +343,7 @@ TEST_CASE("node memory/cpu limit", "[node]")
 			<node name="test_node_default" pkg="rosmon_core" type="abort" />
 			<node name="test_node_custom" pkg="rosmon_core" type="abort" rosmon-memory-limit="200" rosmon-cpu-limit="0.2" />
 
-			<group rosmon-memory-limit="100">
+			<group rosmon-memory-limit="100" enable-coredumps="false">
 				<node name="test_node_grouped" pkg="rosmon_core" type="abort" />
 			</group>
 		</launch>
@@ -364,4 +364,5 @@ TEST_CASE("node memory/cpu limit", "[node]")
 
 	auto grouped = getNode(nodes, "test_node_grouped");
 	CHECK(grouped->memoryLimitByte() == 100);
+	CHECK(!grouped->coredumpsEnabled());
 }


### PR DESCRIPTION
This addresses #116 by supporting the following attributes on all scopes (`launch`, `group`, `node`, `include`):

 * `enable-coredumps`
 * `rosmon-memory-limit`
 * `rosmon-cpu-limit`
 * `rosmon-stop-timeout`

This makes it possible to include launch files designed for roslaunch, but adjust the rosmon-specific parameters at least globally.