### PR TITLE
Prevent infinite coredump aggregation & support systemd-coredump

### DIFF
--- a/rosmon_core/src/monitor/node_monitor.h
+++ b/rosmon_core/src/monitor/node_monitor.h
@@ -236,6 +236,7 @@ private:
 	uint64_t m_memory = 0;
 
 	std::string m_processWorkingDirectory;
+	std::string m_lastWorkingDirectory;
 	bool m_processWorkingDirectoryCreated = false;
 
 	bool m_firstStart = true;

--- a/rosmon_core/test/abort.launch
+++ b/rosmon_core/test/abort.launch
@@ -1,0 +1,3 @@
+<launch>
+	<node name="abort" pkg="rosmon_core" type="abort" />
+</launch>


### PR DESCRIPTION
This addresses #107 by the following two changes:

 * direct support for `systemd-coredump`, which then manages core dump storage for us.
 * if `systemd-coredump` is not installed / not active, then we at least delete core dumps from two runs ago - such that only the last core dump is kept.