### PR TITLE
Respect leading slashes in rosparam YAML keys

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -927,9 +927,14 @@ void LaunchConfig::loadYAMLParams(const ParseContext& ctx, const YAML::Node& n, 
 			// Pass 2: Everything else.
 			for(YAML::const_iterator it = n.begin(); it != n.end(); ++it)
 			{
-				if(it->first.as<std::string>() != "<<")
+				auto key = it->first.as<std::string>();
+				if(key != "<<")
 				{
-					loadYAMLParams(ctx, it->second, prefix + "/" + it->first.as<std::string>());
+					// Load "global" params without prefix (see #130)
+					if(!key.empty() && key[0] == '/')
+						loadYAMLParams(ctx, it->second, key);
+					else
+						loadYAMLParams(ctx, it->second, prefix + "/" + it->first.as<std::string>());
 				}
 			}
 

--- a/rosmon_core/test/xml/test_rosparam.cpp
+++ b/rosmon_core/test/xml/test_rosparam.cpp
@@ -254,5 +254,35 @@ class6:
 	checkTypedParam<double>(params, class_ns + "/testclass/param2", XmlRpc::XmlRpcValue::TypeDouble, 10.0);
 	checkTypedParam<std::string>(params, class_ns + "/testclass/param3", XmlRpc::XmlRpcValue::TypeString, "hello");
 	checkTypedParam<int>(params, class_ns + "/testclass/testparam", XmlRpc::XmlRpcValue::TypeInt, 140);
+}
 
+TEST_CASE("rosparam /param", "[rosparam]")
+{
+	LaunchConfig config;
+	config.parseString(R"EOF(
+		<launch>
+<rosparam ns="ns">
+/fake_param: 20.0
+namespace:
+  /other_param: 10.0
+  /global_ns:
+    third_param: 5.0
+</rosparam>
+		</launch>
+	)EOF");
+
+	config.evaluateParameters();
+
+	CAPTURE(config.parameters());
+
+	auto& params = config.parameters();
+
+	double param1 = getTypedParam<double>(params, "/fake_param", XmlRpc::XmlRpcValue::TypeDouble);
+	CHECK(param1 == Approx(20.0));
+
+	double param2 = getTypedParam<double>(params, "/other_param", XmlRpc::XmlRpcValue::TypeDouble);
+	CHECK(param2 == Approx(10.0));
+
+	double param3 = getTypedParam<double>(params, "/global_ns/third_param", XmlRpc::XmlRpcValue::TypeDouble);
+	CHECK(param3 == Approx(5.0));
 }


### PR DESCRIPTION
See #130 for bug report and example. Basically, `roslaunch` respects leading slashes during key resolution, we don't. There's no spec on this and I don't know what's better, but we have to match whatever `roslaunch` is doing, as always.