### PR TITLE
Inidicate when a node is actually Idle (e.g. stopped)

### DIFF
--- a/rosmon_core/src/diagnostics_publisher.cpp
+++ b/rosmon_core/src/diagnostics_publisher.cpp
@@ -85,11 +85,16 @@ void DiagnosticsPublisher::publish(const std::vector<NodeMonitor::Ptr>& state)
 		}
 		else
 		{
+			if (nodeState->state() == NodeMonitor::STATE_IDLE)
+			{
+				msg = "node idle ";
+			}
+
 			if(nodeState->numRespawnsAllowed() >= 0 &&
 				 nodeState->restartCount() > static_cast<unsigned int>(nodeState->numRespawnsAllowed()))
 			{
 				nodeStatus.level = diagnostic_msgs::DiagnosticStatus::WARN;
-				msg = "restart count > " + std::to_string(nodeState->numRespawnsAllowed()) +
+				msg += "restart count > " + std::to_string(nodeState->numRespawnsAllowed()) +
 							"! (" + std::to_string(nodeState->restartCount()) + ")";
 			}
 


### PR DESCRIPTION
In some of our use-cases it is especially useful to see when a node is stopped/idle. 