### PR TITLE
Resolves #145 by providing a number of restarts threshold per node vi…

### DIFF
--- a/rosmon_core/src/diagnostics_publisher.cpp
+++ b/rosmon_core/src/diagnostics_publisher.cpp
@@ -85,10 +85,12 @@ void DiagnosticsPublisher::publish(const std::vector<NodeMonitor::Ptr>& state)
 		}
 		else
 		{
-			if(nodeState->restartCount() > 0)
+			if(nodeState->numRespawnsAllowed() >= 0 &&
+				 nodeState->restartCount() > nodeState->numRespawnsAllowed())
 			{
 				nodeStatus.level = diagnostic_msgs::DiagnosticStatus::WARN;
-				msg = "restart count > 0! (" + std::to_string(nodeState->restartCount()) + ")";
+				msg = "restart count > " + std::to_string(nodeState->numRespawnsAllowed()) +
+							"! (" + std::to_string(nodeState->restartCount()) + ")";
 			}
 
 			if(nodeState->memory() > nodeState->memoryLimit())

--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -354,6 +354,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext& attr_ctx)
 	const char* ns = element->Attribute("ns");
 	const char* respawn = element->Attribute("respawn");
 	const char* respawnDelay = element->Attribute("respawn_delay");
+	const char* nRespawnsAllowed = element->Attribute("rosmon-restart-warn-threshold");
 	const char* required = element->Attribute("required");
 	const char* launchPrefix = element->Attribute("launch-prefix");
 	const char* cwd = element->Attribute("cwd");
@@ -423,6 +424,21 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext& attr_ctx)
 			}
 
 			node->setRespawnDelay(ros::WallDuration(seconds));
+		}
+
+		if (nRespawnsAllowed)
+		{
+			int n_respawns;
+			try
+			{
+				n_respawns = boost::lexical_cast<int>(attr_ctx.evaluate(nRespawnsAllowed));
+			}
+			catch(boost::bad_lexical_cast&)
+			{
+				throw ctx.error("bad rosmon-restart-warn-threshold value '{}'", nRespawnsAllowed);
+			}
+
+			node->setNumRespawnsAllowed(n_respawns);
 		}
 	}
 

--- a/rosmon_core/src/launch/node.cpp
+++ b/rosmon_core/src/launch/node.cpp
@@ -102,6 +102,11 @@ void Node::setRespawnDelay(const ros::WallDuration& respawnDelay)
 	m_respawnDelay = respawnDelay;
 }
 
+void Node::setNumRespawnsAllowed(int numRespawnsAllowed)
+{
+	m_numRespawnsAllowed = numRespawnsAllowed;
+}
+
 void Node::setLaunchPrefix(const std::string& launchPrefix)
 {
 	wordexp_t tokens;

--- a/rosmon_core/src/launch/node.h
+++ b/rosmon_core/src/launch/node.h
@@ -33,6 +33,7 @@ public:
 
 	void setRespawn(bool respawn);
 	void setRespawnDelay(const ros::WallDuration& respawnDelay);
+	void setNumRespawnsAllowed(int numRespawnsAllowed);
 
 	void setLaunchPrefix(const std::string& launchPrefix);
 
@@ -78,6 +79,9 @@ public:
 
 	ros::WallDuration respawnDelay() const
 	{ return m_respawnDelay; }
+
+	int numRespawnsAllowed() const
+	{ return m_numRespawnsAllowed; }
 
 	void setRequired(bool required);
 
@@ -126,6 +130,7 @@ private:
 
 	bool m_respawn;
 	ros::WallDuration m_respawnDelay;
+	int m_numRespawnsAllowed = 0;  // Will warn on any respawn by default
 
 	bool m_required;
 

--- a/rosmon_core/src/monitor/node_monitor.h
+++ b/rosmon_core/src/monitor/node_monitor.h
@@ -149,6 +149,9 @@ public:
 	inline unsigned int restartCount() const
 	{ return m_restartCount; }
 
+	inline int numRespawnsAllowed() const
+	{ return m_launchNode->numRespawnsAllowed(); }
+
 	inline uint64_t memoryLimit() const
 	{ return m_launchNode->memoryLimitByte();}
 

--- a/rosmon_core/test/respawns.launch
+++ b/rosmon_core/test/respawns.launch
@@ -1,0 +1,10 @@
+<launch>
+	<node name="test_respawns_ok" pkg="rosmon_core" type="test_node.py" respawn="true" rosmon-restart-warn-threshold="-1">
+	</node>
+
+	<node name="test_2_respawns_allowed" pkg="rosmon_core" type="test_node.py" respawn="true" rosmon-restart-warn-threshold="2">
+	</node>
+
+	<node name="test_no_respawns_allowed" pkg="rosmon_core" type="test_node.py" respawn="true" rosmon-restart-warn-threshold="0">
+	</node>
+</launch>


### PR DESCRIPTION
Resolves #145 by providing a number of restarts threshold per node via ROS-launch arguments

- Default is 0 respawns
- value of -1 allows infinite respawns
- any other value allows that number of respawns before issuing a warning

I also included a small test-launch-file for a manual test.