### PR TITLE
Clear ONLCR o_flag on pty to avoid converting \n into \r\n

### DIFF
--- a/rosmon_core/src/monitor/node_monitor.h
+++ b/rosmon_core/src/monitor/node_monitor.h
@@ -218,6 +218,8 @@ private:
 	void checkStop();
 	void gatherCoredump(int signal);
 
+	void clearOnlcrFlagOnPty(int fd, const std::string& ptyName);
+
 	launch::Node::ConstPtr m_launchNode;
 
 	FDWatcher::Ptr m_fdWatcher;

--- a/rosmon_core/src/monitor/node_monitor.h
+++ b/rosmon_core/src/monitor/node_monitor.h
@@ -218,7 +218,7 @@ private:
 	void checkStop();
 	void gatherCoredump(int signal);
 
-	void clearOnlcrFlagOnPty(int fd, const std::string& ptyName);
+	std::pair<int,int> createPTY();
 
 	launch::Node::ConstPtr m_launchNode;
 


### PR DESCRIPTION
Linux creates a new unix98 pty with the `ONLCR` flag set, see:
[pty.c:941](https://elixir.bootlin.com/linux/v5.13.5/source/drivers/tty/pty.c#L941)
and [tty_io.c:125](https://elixir.bootlin.com/linux/v5.13.5/source/drivers/tty/tty_io.c#L125).

The flag [ONLCR](https://www.gnu.org/software/libc/manual/html_node/Output-Modes.html#index-ONLCR) replaces `\n` with `\r\n` as done in [n_tty.c:444](https://elixir.bootlin.com/linux/v5.13.5/source/drivers/tty/n_tty.c#L444).

This can be an issue while using rosmon in a Docker container with the journald log driver.

Docker removes the trailing `\n` in log lines [here](https://github.com/moby/moby/blob/1f42dd5e91a643d8d4e3ef009fc8ba6e78c391d1/daemon/logger/copier.go#L104-L111).
This might not be obvious, but it is tested [here](https://github.com/moby/moby/blob/1f42dd5e91a643d8d4e3ef009fc8ba6e78c391d1/daemon/logger/copier_test.go#L52-L121).
And discussed [here](https://github.com/moby/moby/issues/15722#issuecomment-216186551).

And systemd-journald treats a log line with a non printable character, including
a trailing `\r`, as a binary blob and does not displays it with `journalctl`
as discussed [here](https://github.com/systemd/systemd/issues/3416)
and [here](https://github.com/moby/moby/pull/22450).

To fix the issue, the `\r` should be removed. And from [this PR](https://github.com/opencontainers/runc/pull/1146),
I have learned its origin and how to get rid of it.