### PR TITLE
core/launch: support YAML merge keys inside arrays

### DIFF
--- a/rosmon_core/test/xml/test_rosparam.cpp
+++ b/rosmon_core/test/xml/test_rosparam.cpp
@@ -205,6 +205,10 @@ class6:
   &lt;&lt;: *commonclass
   testclass:
     param2: 10.0
+array:
+  - &lt;&lt;: *common
+    A: 23
+    C: 99
 </rosparam>
 		</launch>
 	)EOF");
@@ -254,6 +258,20 @@ class6:
 	checkTypedParam<double>(params, class_ns + "/testclass/param2", XmlRpc::XmlRpcValue::TypeDouble, 10.0);
 	checkTypedParam<std::string>(params, class_ns + "/testclass/param3", XmlRpc::XmlRpcValue::TypeString, "hello");
 	checkTypedParam<int>(params, class_ns + "/testclass/testparam", XmlRpc::XmlRpcValue::TypeInt, 140);
+
+	{
+		// Structs in arrays (#150)
+		auto array = getTypedParam<XmlRpc::XmlRpcValue>(params, "/array", XmlRpc::XmlRpcValue::TypeArray);
+		REQUIRE(array.size() == 1);
+		auto element = array[0];
+		REQUIRE(element.getType() == XmlRpc::XmlRpcValue::TypeStruct);
+
+		CAPTURE(element);
+		CHECK(element.hasMember("A"));
+		CHECK(static_cast<int>(element["A"]) == 23);
+		CHECK(element.hasMember("param1"));
+		CHECK(static_cast<bool>(element["param1"]) == true);
+	}
 }
 
 TEST_CASE("rosparam /param", "[rosparam]")


### PR DESCRIPTION
This should fix #150, where problems with the non-standard YAML merge keys `<<` inside arrays were noticed:

```yaml
defaults: &defaults
  A: 1
  B: 2
array:
  - <<: *defaults
    A: 23
    C: 99
```

Previously, merge keys where only handled on a per-parameter level. Since arrays are imported onto the ROS parameter server as a single XmlRpcValue, merge keys inside were not handled at all. We now do that inside `yamlToXmlRpc()`, which fixes this situation.

It also adds a rudimentary unit test.