### PR TITLE
logger.cpp: Open logfiles in append mode to allow copytruncate operations

### DIFF
--- a/rosmon_core/src/logger.cpp
+++ b/rosmon_core/src/logger.cpp
@@ -19,7 +19,7 @@ namespace rosmon
 Logger::Logger(const std::string& path, bool flush)
  : m_flush(flush)
 {
-	m_file = fopen(path.c_str(), "we");
+	m_file = fopen(path.c_str(), "wea+");
 	if(!m_file)
 	{
 		throw std::runtime_error(fmt::format(


### PR DESCRIPTION
I just realized I previously did not test this properly. This option might work, but I did not test it.

This is an attempt at fixing 