### PR TITLE
Adds Check for Global Group Namespace Tag

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -34,7 +34,9 @@ const char* UNSET_MARKER = "~~~~~ ROSMON-UNSET ~~~~~";
 ParseContext ParseContext::enterScope(const std::string& prefix)
 {
 	ParseContext ret = *this;
-	ret.m_prefix = ros::names::clean(ret.m_prefix + prefix) + "/";
+
+	const bool global_prefix = (!prefix.empty() && prefix.front() == '/');
+	ret.m_prefix = ros::names::clean(global_prefix ? prefix : (ret.m_prefix + prefix)) + "/";
 
 	return ret;
 }

--- a/rosmon_core/test/basic.launch
+++ b/rosmon_core/test/basic.launch
@@ -38,6 +38,13 @@ yaml:
 	<rosparam command="load" file="$(dirname)/empty.yaml" />
 	<rosparam></rosparam>
 
+	<!-- Test nested global group namespace -->
+	<group ns="nested">
+		<group ns="/foo">
+			<param name="bar" value="True" />
+		</group>
+	</group>
+
 	<node name="test1" pkg="rosmon_core" type="test_node.py">
 		<remap from="~input" to="/test_input" />
 		<remap from="~output" to="/test_output" />

--- a/rosmon_core/test/basic.py
+++ b/rosmon_core/test/basic.py
@@ -106,6 +106,9 @@ class BasicTest(unittest.TestCase):
 	def test_arg_passing(self):
 		self.assertEqual(self.get_param("test_argument"), 123)
 
+	def test_global_nested_ns(self):
+		self.assertEqual(self.get_param("/foo/bar"), True)
+
 	def test_global_remapping(self):
 		pub = rospy.Publisher('/remapped_test_input', String, queue_size=5, latch=True)
 


### PR DESCRIPTION
This commit addresses differences between `rosmon` and `roslaunch` when parsing a nested global `group` namespace (`ns`) tag. If a nested `group` contains a global `ns` tag, it is no longer appended to the parent group.

Resolves xqms#160