### PR TITLE
rosparam: strip whitespace inside deg() and rad() expressions

### DIFF
--- a/rosmon_core/src/launch/yaml_params.cpp
+++ b/rosmon_core/src/launch/yaml_params.cpp
@@ -5,6 +5,7 @@
 #include "launch_config.h"
 #include "substitution.h"
 #include "substitution_python.h"
+#include "string_utils.h"
 
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -160,10 +161,11 @@ XmlRpc::XmlRpcValue yamlToXmlRpc(const ParseContext& ctx, const YAML::Node& n)
 
 		if(boost::starts_with(str, "deg(") && boost::ends_with(str, ")"))
 		{
+			std::string arg = string_utils::strip(str.substr(4, str.size() - 5));
 			try
 			{
 				return XmlRpc::XmlRpcValue(
-					evaluateROSParamPython(str.substr(4, str.size() - 5)) * M_PI / 180.0
+					evaluateROSParamPython(arg) * M_PI / 180.0
 				);
 			}
 			catch(SubstitutionException& e)
@@ -174,9 +176,10 @@ XmlRpc::XmlRpcValue yamlToXmlRpc(const ParseContext& ctx, const YAML::Node& n)
 
 		if(boost::starts_with(str, "rad(") && boost::ends_with(str, ")"))
 		{
+			std::string arg = string_utils::strip(str.substr(4, str.size() - 5));
 			try
 			{
-				return XmlRpc::XmlRpcValue(evaluateROSParamPython(str.substr(4, str.size() - 5)));
+				return XmlRpc::XmlRpcValue(evaluateROSParamPython(arg));
 			}
 			catch(SubstitutionException& e)
 			{

--- a/rosmon_core/test/xml/test_rosparam.cpp
+++ b/rosmon_core/test/xml/test_rosparam.cpp
@@ -147,6 +147,7 @@ test_ns:
   param2: deg(180)
   param3: !degrees 181.0
   param4: !radians 3.14169
+  param5: deg(  0.1)
 </rosparam>
 		</launch>
 	)EOF");
@@ -168,6 +169,9 @@ test_ns:
 
 	double param4 = getTypedParam<double>(params, "/test_ns/param4", XmlRpc::XmlRpcValue::TypeDouble);
 	CHECK(param4 == Approx(3.14169));
+
+	double param5 = getTypedParam<double>(params, "/test_ns/param5", XmlRpc::XmlRpcValue::TypeDouble);
+	CHECK(param5 == Approx(0.1 * M_PI / 180.0));
 }
 
 TEST_CASE("merge keys", "[rosparam]")


### PR DESCRIPTION
Fixes #163.