### PR TITLE
rosmon: Fix installation of wrapper script in devel spaces

### DIFF
--- a/rosmon/CMakeLists.txt
+++ b/rosmon/CMakeLists.txt
@@ -6,7 +6,8 @@ find_package(catkin)
 
 catkin_package()
 
-catkin_install_python(
+install(
 	PROGRAMS src/rosmon
 	DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+


### PR DESCRIPTION
Fixes issue #165. Previously, we installed the wrapper shell script via `catkin_install_python()`, which is obviously wrong. Just install it using `install(PROGRAMS ...)` instead and everything works fine in devel and install spaces.