### PR TITLE
core: support importing args from included files

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -1005,12 +1005,13 @@ void LaunchConfig::loadYAMLParams(const ParseContext& ctx, const YAML::Node& n, 
 	}
 }
 
-void LaunchConfig::parseInclude(TiXmlElement* element, ParseContext ctx)
+void LaunchConfig::parseInclude(TiXmlElement* element, ParseContext& ctx)
 {
 	const char* file = element->Attribute("file");
 	const char* ns = element->Attribute("ns");
 	const char* passAllArgs = element->Attribute("pass_all_args");
 	const char* clearParams = element->Attribute("clear_params");
+	const char* importArgs = element->Attribute("rosmon-import-args");
 
 	if(!file)
 		throw ctx.error("<include> file attribute is mandatory");
@@ -1079,6 +1080,13 @@ void LaunchConfig::parseInclude(TiXmlElement* element, ParseContext ctx)
 	childCtx.setFilename(fullFile);
 
 	parse(document.RootElement(), &childCtx);
+
+	// Import args from child context if requested
+	if(importArgs && ctx.parseBool(importArgs, element->Row()))
+	{
+		for(auto& pair : childCtx.arguments())
+			ctx.setArg(pair.first, pair.second, true);
+	}
 }
 
 void LaunchConfig::parseArgument(TiXmlElement* element, ParseContext& ctx)

--- a/rosmon_core/src/launch/launch_config.h
+++ b/rosmon_core/src/launch/launch_config.h
@@ -237,7 +237,7 @@ private:
 	void parseNode(TiXmlElement* element, ParseContext& ctx);
 	void parseParam(TiXmlElement* element, ParseContext& ctx, ParamContext paramContext = PARAM_GENERAL);
 	void parseROSParam(TiXmlElement* element, ParseContext& ctx);
-	void parseInclude(TiXmlElement* element, ParseContext ctx);
+	void parseInclude(TiXmlElement* element, ParseContext& ctx);
 	void parseArgument(TiXmlElement* element, ParseContext& ctx);
 	void parseEnv(TiXmlElement* element, ParseContext& ctx);
 	void parseRemap(TiXmlElement* element, ParseContext& ctx);


### PR DESCRIPTION
This adds support for a `rosmon-import-args` attribute on the `<include>` tag. When set to `true`, rosmon will import all args set in the included file into the current scope.