### PR TITLE
Systemd-journal & syslog support

### DIFF
--- a/rosmon_core/CMakeLists.txt
+++ b/rosmon_core/CMakeLists.txt
@@ -90,6 +90,7 @@ add_executable(rosmon
 	src/monitor/node_monitor.cpp
 	src/monitor/monitor.cpp
 	src/monitor/linux_process_info.cpp
+	src/monitor/log_parser.cpp
 	src/diagnostics_publisher.cpp
 	src/ui.cpp
 	src/husl/husl.c
@@ -158,6 +159,14 @@ if(CATKIN_ENABLE_TESTING)
 		)
 		target_link_libraries(test_xml_loading
 			rosmon_launch_config
+			${catch_ros_LIBRARIES}
+		)
+
+		catch_add_test(test_monitor
+			src/monitor/log_parser.cpp
+			test/monitor/test_log_parser.cpp
+		)
+		target_link_libraries(test_xml_loading
 			${catch_ros_LIBRARIES}
 		)
 	else()

--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -1265,5 +1265,10 @@ void LaunchConfig::setWarningOutput(std::ostream* output)
 	m_warningOutput = output;
 }
 
+void LaunchConfig::setNodeLogDir(const std::string& dir)
+{
+	m_nodeLogDir = dir;
+}
+
 }
 }

--- a/rosmon_core/src/launch/launch_config.h
+++ b/rosmon_core/src/launch/launch_config.h
@@ -198,6 +198,10 @@ public:
 
 	void setOutputAttrMode(OutputAttr mode);
 
+	void setNodeLogDir(const std::string& logDir);
+	std::string nodeLogDir() const
+	{ return m_nodeLogDir; }
+
 	void parse(const std::string& filename, bool onlyArguments = false);
 	void parseString(const std::string& input, bool onlyArguments = false);
 
@@ -276,6 +280,8 @@ private:
 	bool m_disableUI = false;
 
 	std::ostream* m_warningOutput = &std::cerr;
+
+	std::string m_nodeLogDir;
 };
 
 template<typename... Args>

--- a/rosmon_core/src/log_event.h
+++ b/rosmon_core/src/log_event.h
@@ -19,6 +19,7 @@ public:
 		 * ANSI escape codes. */
 		Raw,
 
+		Debug,
 		Info,
 		Warning,
 		Error

--- a/rosmon_core/src/log_event.h
+++ b/rosmon_core/src/log_event.h
@@ -5,6 +5,7 @@
 #define ROSMON_LOG_EVENT_H
 
 #include <string>
+#include <sstream>
 
 namespace rosmon
 {
@@ -35,6 +36,26 @@ public:
 	LogEvent(std::string source, std::string message, Type type = Type::Raw)
 	 : source{std::move(source)}, message{std::move(message)}, type{type}
 	{}
+
+	std::string coloredString() const
+	{
+		auto colorize = [](const char* prefix, const std::string& str){
+			std::stringstream ss;
+			ss << prefix << str << "\e[0m";
+			return ss.str();
+		};
+
+		switch(type)
+		{
+			case Type::Raw: return message;
+			case Type::Debug: return colorize("\e[32m", message);
+			case Type::Info: return colorize("\e[0m", message);
+			case Type::Warning: return colorize("\e[33m", message);
+			case Type::Error: return colorize("\e[31m", message);
+		}
+
+		return message;
+	}
 
 	std::string source;
 	std::string message;

--- a/rosmon_core/src/logger.cpp
+++ b/rosmon_core/src/logger.cpp
@@ -28,6 +28,7 @@ namespace
 			case LogEvent::Type::Warning: return 4;
 			case LogEvent::Type::Info: return 6;
 			case LogEvent::Type::Raw: return 6;
+			case LogEvent::Type::Debug: return 7;
 		}
 
 		return 6;

--- a/rosmon_core/src/logger.cpp
+++ b/rosmon_core/src/logger.cpp
@@ -84,7 +84,8 @@ void FileLogger::log(const LogEvent& event)
 
 SyslogLogger::SyslogLogger(const std::string& launchFileName)
 {
-	openlog(fmt::format("rosmon[{}]", launchFileName).c_str(), 0, LOG_USER);
+	m_tag = fmt::format("rosmon@{}", launchFileName);
+	openlog(m_tag.c_str(), 0, LOG_USER);
 }
 
 void SyslogLogger::log(const LogEvent& event)

--- a/rosmon_core/src/logger.cpp
+++ b/rosmon_core/src/logger.cpp
@@ -2,18 +2,24 @@
 // Author: Max Schwarz <max.schwarz@uni-bonn.de>
 
 #include "logger.h"
+#include "fmt/format.h"
 
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
 #include <ctime>
 #include <stdexcept>
+#include <iterator>
 
 #include <sys/time.h>
 
 #include <fmt/format.h>
 
 #include <syslog.h>
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
 
 namespace rosmon
 {
@@ -92,6 +98,67 @@ SyslogLogger::SyslogLogger(const std::string& launchFileName)
 void SyslogLogger::log(const LogEvent& event)
 {
 	syslog(prioFromEventType(event.type), "%20s: %s", event.source.c_str(), event.message.c_str());
+}
+
+
+SystemdLogger::SystemdLogger(const std::string& launchFileName)
+ : m_launchFileName{launchFileName}
+{
+	m_fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	if(m_fd < 0)
+		throw std::runtime_error{fmt::format("Could not create socket: {}", strerror(errno))};
+
+	sockaddr_un addr{};
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, "/run/systemd/journal/socket", sizeof(addr.sun_path)-1);
+
+	if(connect(m_fd, reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)) != 0)
+		throw NotAvailable{fmt::format("Systemd Journal not available: {}", strerror(errno))};
+}
+
+SystemdLogger::~SystemdLogger()
+{
+	if(m_fd >= 0)
+		close(m_fd);
+}
+
+void SystemdLogger::log(const LogEvent& event)
+{
+	fmt::memory_buffer buffer;
+
+	fmt::format_to(std::back_inserter(buffer),
+		"PRIORITY={}\n"
+		"ROSMON_LAUNCH_FILE={}\n"
+		"ROSMON_NODE={}\n"
+		"SYSLOG_IDENTIFIER=rosmon@{}\n",
+		prioFromEventType(event.type),
+		m_launchFileName,
+		event.source,
+		m_launchFileName
+	);
+
+	std::string msg = fmt::format("{}: {}", event.source, event.message);
+
+	if(msg.find('\n') == std::string::npos)
+		fmt::format_to(std::back_inserter(buffer), "MESSAGE={}\n", msg);
+	else
+	{
+		buffer.append(std::string{"MESSAGE\n"});
+		std::array<uint8_t, 8> size;
+		uint64_t sizeInt = msg.length();
+		for(int i = 0; i < 8; ++i)
+		{
+			size[i] = sizeInt & 0xFF;
+			sizeInt >>= 8;
+		}
+
+		buffer.append(size);
+		buffer.append(msg);
+		buffer.append(std::string{"\n"});
+	}
+
+	if(write(m_fd, buffer.data(), buffer.size()) < 0)
+		fprintf(stderr, "Could not write to systemd log: %s\n", strerror(errno));
 }
 
 }

--- a/rosmon_core/src/logger.cpp
+++ b/rosmon_core/src/logger.cpp
@@ -108,6 +108,10 @@ SystemdLogger::SystemdLogger(const std::string& launchFileName)
 	if(m_fd < 0)
 		throw std::runtime_error{fmt::format("Could not create socket: {}", strerror(errno))};
 
+	int size = 8*1024*1024;
+	if(setsockopt(m_fd, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size)) < 0)
+		perror("WARNING: Could not increase SO_SNDBUF size");
+
 	sockaddr_un addr{};
 	addr.sun_family = AF_UNIX;
 	strncpy(addr.sun_path, "/run/systemd/journal/socket", sizeof(addr.sun_path)-1);

--- a/rosmon_core/src/logger.h
+++ b/rosmon_core/src/logger.h
@@ -11,10 +11,16 @@
 namespace rosmon
 {
 
+class Logger
+{
+public:
+	virtual void log(const LogEvent& event) = 0;
+};
+
 /**
  * @brief Write log messages into a log file
  **/
-class Logger
+class FileLogger : public Logger
 {
 public:
 	/**
@@ -22,14 +28,26 @@ public:
 	 *
 	 * @param path Path to the output file
 	 **/
-	explicit Logger(const std::string& path, bool flush = false);
-	~Logger();
+	explicit FileLogger(const std::string& path, bool flush = false);
+	~FileLogger();
 
 	//! Log message
-	void log(const LogEvent& event);
+	void log(const LogEvent& event) override;
 private:
 	FILE* m_file = nullptr;
 	bool m_flush = false;
+};
+
+/**
+ * @brief Write log messages to syslog
+ **/
+class SyslogLogger : public Logger
+{
+public:
+	explicit SyslogLogger(const std::string& launchFileName);
+	~SyslogLogger();
+
+	void log(const LogEvent& event) override;
 };
 
 }

--- a/rosmon_core/src/logger.h
+++ b/rosmon_core/src/logger.h
@@ -4,6 +4,7 @@
 #ifndef LOGGER_H
 #define LOGGER_H
 
+#include <memory>
 #include <string>
 
 #include "log_event.h"
@@ -51,6 +52,30 @@ public:
 
 private:
 	std::string m_tag;
+};
+
+/**
+ * @brief Write log messages to systemd journal
+ **/
+class SystemdLogger : public Logger
+{
+public:
+	class NotAvailable : public std::runtime_error
+	{
+	public:
+		NotAvailable(const std::string& msg)
+		 : std::runtime_error{msg}
+		{}
+	};
+
+	explicit SystemdLogger(const std::string& launchFileName);
+	~SystemdLogger();
+
+	void log(const LogEvent& event) override;
+
+private:
+	std::string m_launchFileName;
+	int m_fd = -1;
 };
 
 }

--- a/rosmon_core/src/logger.h
+++ b/rosmon_core/src/logger.h
@@ -48,6 +48,9 @@ public:
 	~SyslogLogger();
 
 	void log(const LogEvent& event) override;
+
+private:
+	std::string m_tag;
 };
 
 }

--- a/rosmon_core/src/monitor/log_parser.cpp
+++ b/rosmon_core/src/monitor/log_parser.cpp
@@ -3,6 +3,8 @@
 
 #include "log_parser.h"
 
+#include <algorithm>
+#include <cstring>
 #include <vector>
 
 namespace rosmon
@@ -42,7 +44,7 @@ public:
 		return LogEvent::Type::Info;
 	}
 
-	void process(char c)
+	void process(char c, const std::chrono::steady_clock::time_point& time)
 	{
 		m_buffer.push_back(c);
 
@@ -73,6 +75,7 @@ public:
 				else if(c == 'm')
 				{
 					m_msgBegin = m_buffer.size();
+					m_msgStartTime = time;
 					m_state = State::TypedMsgContent;
 				}
 				else
@@ -119,7 +122,7 @@ public:
 					std::string msg{m_buffer.data() + m_msgBegin, m_msgEnd - m_msgBegin};
 
 					if(m_cb)
-						m_cb(Event{msg, typeFromColorCode(m_colorCode)});
+						m_cb(Event{std::move(msg), typeFromColorCode(m_colorCode)});
 
 					m_state = State::ColorEscape1;
 					m_buffer.clear();
@@ -133,7 +136,7 @@ public:
 					std::string msg{m_buffer.data(), m_buffer.size()-1};
 
 					if(m_cb)
-						m_cb(Event{msg, LogEvent::Type::Raw});
+						m_cb(Event{std::move(msg), LogEvent::Type::Raw});
 
 					m_state = State::ColorEscape1;
 					m_buffer.clear();
@@ -141,6 +144,40 @@ public:
 
 				break;
 		}
+	}
+
+	void checkPending(const std::chrono::steady_clock::time_point& time = std::chrono::steady_clock::now())
+	{
+		if(m_state == State::RawMsgContent)
+			return;
+
+		if(time - m_msgStartTime > std::chrono::milliseconds(250))
+			flush();
+	}
+
+	void flush()
+	{
+		if(m_buffer.empty())
+			return;
+
+		// Emit completed lines
+		while(true)
+		{
+			auto it = std::find(m_buffer.begin(), m_buffer.end(), '\n');
+			if(it == m_buffer.end())
+				break;
+
+			std::size_t size = it - m_buffer.begin();
+			std::string msg{m_buffer.data(), size};
+
+			if(m_cb)
+				m_cb(Event{std::move(msg), LogEvent::Type::Raw});
+
+			std::memmove(m_buffer.data(), m_buffer.data() + size + 1, m_buffer.size() - size - 1);
+			m_buffer.resize(m_buffer.size() - size - 1);
+		}
+
+		m_state = State::ColorEscape1;
 	}
 
 	State m_state = State::ColorEscape1;
@@ -151,6 +188,7 @@ public:
 
 	std::size_t m_msgBegin = 0;
 	std::size_t m_msgEnd = 0;
+	std::chrono::steady_clock::time_point m_msgStartTime;
 
 	std::function<void(LogParser::Event&&)> m_cb;
 };
@@ -164,15 +202,25 @@ LogParser::~LogParser()
 {
 }
 
-void LogParser::process(const char* input, std::size_t size)
+void LogParser::process(const char* input, std::size_t size, const std::chrono::steady_clock::time_point& time)
 {
 	for(std::size_t i = 0; i < size; ++i)
-		m_d->process(input[i]);
+		m_d->process(input[i], time);
 }
 
 void LogParser::setCallback(const std::function<void(Event&&)>& cb)
 {
 	m_d->m_cb = cb;
+}
+
+void LogParser::checkPending(const std::chrono::steady_clock::time_point& time)
+{
+	m_d->checkPending(time);
+}
+
+void LogParser::flush()
+{
+	m_d->flush();
 }
 
 }

--- a/rosmon_core/src/monitor/log_parser.cpp
+++ b/rosmon_core/src/monitor/log_parser.cpp
@@ -1,0 +1,179 @@
+// Splits the log stream into individual messages
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include "log_parser.h"
+
+#include <vector>
+
+namespace rosmon
+{
+namespace monitor
+{
+
+class LogParser::Private
+{
+public:
+	enum class State
+	{
+		ColorEscape1,
+		ColorEscape2,
+		ColorEscape3,
+
+		RawMsgContent,
+
+		TypedMsgContent,
+
+		EndEscape1,
+		EndEscape2,
+		EndEscape3,
+		EndEscape4
+	};
+
+	static LogEvent::Type typeFromColorCode(int code)
+	{
+		switch(code)
+		{
+			case 0: return LogEvent::Type::Info;
+			case 31: return LogEvent::Type::Error;
+			case 32: return LogEvent::Type::Debug;
+			case 33: return LogEvent::Type::Warning;
+		}
+
+		return LogEvent::Type::Info;
+	}
+
+	void process(char c)
+	{
+		m_buffer.push_back(c);
+
+		switch(m_state)
+		{
+			case State::ColorEscape1:
+				if(c == '\e')
+					m_state = State::ColorEscape2;
+				else
+					m_state = State::RawMsgContent;
+
+				break;
+
+			case State::ColorEscape2:
+				if(c == '[')
+				{
+					m_state = State::ColorEscape3;
+					m_colorCode = 0;
+				}
+				else
+					m_state = State::RawMsgContent;
+
+				break;
+
+			case State::ColorEscape3:
+				if(std::isdigit(c))
+					m_colorCode = m_colorCode * 10 + (c - '0');
+				else if(c == 'm')
+				{
+					m_msgBegin = m_buffer.size();
+					m_state = State::TypedMsgContent;
+				}
+				else
+					m_state = State::RawMsgContent;
+
+				break;
+
+			case State::TypedMsgContent:
+				if(c == '\e')
+				{
+					m_msgEnd = m_buffer.size() - 1;
+					m_state = State::EndEscape1;
+				}
+
+				break;
+
+			case State::EndEscape1:
+				if(c == '[')
+					m_state = State::EndEscape2;
+				else
+					m_state = State::TypedMsgContent;
+
+				break;
+
+			case State::EndEscape2:
+				if(c == '0')
+					m_state = State::EndEscape3;
+				else
+					m_state = State::TypedMsgContent;
+
+				break;
+
+			case State::EndEscape3:
+				if(c == 'm')
+					m_state = State::EndEscape4;
+				else
+					m_state = State::TypedMsgContent;
+
+				break;
+
+			case State::EndEscape4:
+				if(c == '\n')
+				{
+					std::string msg{m_buffer.data() + m_msgBegin, m_msgEnd - m_msgBegin};
+
+					if(m_cb)
+						m_cb(Event{msg, typeFromColorCode(m_colorCode)});
+
+					m_state = State::ColorEscape1;
+					m_buffer.clear();
+				}
+
+				break;
+
+			case State::RawMsgContent:
+				if(c == '\n')
+				{
+					std::string msg{m_buffer.data(), m_buffer.size()-1};
+
+					if(m_cb)
+						m_cb(Event{msg, LogEvent::Type::Raw});
+
+					m_state = State::ColorEscape1;
+					m_buffer.clear();
+				}
+
+				break;
+		}
+	}
+
+	State m_state = State::ColorEscape1;
+
+	int m_colorCode = 0;
+
+	std::vector<char> m_buffer;
+
+	std::size_t m_msgBegin = 0;
+	std::size_t m_msgEnd = 0;
+
+	std::function<void(LogParser::Event&&)> m_cb;
+};
+
+LogParser::LogParser()
+ : m_d{new Private}
+{
+}
+
+LogParser::~LogParser()
+{
+}
+
+void LogParser::process(const char* input, std::size_t size)
+{
+	for(std::size_t i = 0; i < size; ++i)
+		m_d->process(input[i]);
+}
+
+void LogParser::setCallback(const std::function<void(Event&&)>& cb)
+{
+	m_d->m_cb = cb;
+}
+
+}
+}

--- a/rosmon_core/src/monitor/log_parser.h
+++ b/rosmon_core/src/monitor/log_parser.h
@@ -1,0 +1,48 @@
+// Splits the log stream into individual messages
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#ifndef ROSMON_MONITOR_LOG_PARSER_H
+#define ROSMON_MONITOR_LOG_PARSER_H
+
+#include <chrono>
+#include <memory>
+#include <functional>
+
+#include "../log_event.h"
+
+namespace rosmon
+{
+namespace monitor
+{
+
+class LogParser
+{
+public:
+	LogParser();
+	~LogParser();
+
+	struct Event
+	{
+		std::string message;
+		LogEvent::Type severity;
+	};
+
+	void setCallback(const std::function<void(Event&&)>& cb);
+
+	void process(const char* input, std::size_t size, const std::chrono::steady_clock::time_point& time = std::chrono::steady_clock::now());
+
+	inline void processString(const std::string& str, const std::chrono::steady_clock::time_point& time = std::chrono::steady_clock::now())
+	{ process(str.c_str(), str.length(), time); }
+
+	void checkPending();
+
+private:
+	class Private;
+	std::unique_ptr<Private> m_d;
+};
+
+}
+}
+
+
+#endif

--- a/rosmon_core/src/monitor/log_parser.h
+++ b/rosmon_core/src/monitor/log_parser.h
@@ -34,7 +34,9 @@ public:
 	inline void processString(const std::string& str, const std::chrono::steady_clock::time_point& time = std::chrono::steady_clock::now())
 	{ process(str.c_str(), str.length(), time); }
 
-	void checkPending();
+	void checkPending(const std::chrono::steady_clock::time_point& time = std::chrono::steady_clock::now());
+
+	void flush();
 
 private:
 	class Private;

--- a/rosmon_core/src/monitor/monitor.cpp
+++ b/rosmon_core/src/monitor/monitor.cpp
@@ -39,7 +39,7 @@ Monitor::Monitor(launch::LaunchConfig::ConstPtr config, FDWatcher::Ptr watcher)
 {
 	for(auto& launchNode : m_config->nodes())
 	{
-		auto node = std::make_shared<NodeMonitor>(launchNode, m_fdWatcher, m_nh);
+		auto node = std::make_shared<NodeMonitor>(m_config, launchNode, m_fdWatcher, m_nh);
 
 		node->logMessageSignal.connect(logMessageSignal);
 

--- a/rosmon_core/src/monitor/node_monitor.cpp
+++ b/rosmon_core/src/monitor/node_monitor.cpp
@@ -180,6 +180,9 @@ std::vector<std::string> NodeMonitor::composeCommand() const
 	// add parameter for node name
 	cmd.push_back("__name:=" + m_launchNode->name());
 
+	// disable internal logging
+	cmd.push_back("__log:=/dev/null");
+
 	// and finally add remappings.
 	for(auto map : m_launchNode->remappings())
 	{

--- a/rosmon_core/src/monitor/node_monitor.h
+++ b/rosmon_core/src/monitor/node_monitor.h
@@ -7,6 +7,7 @@
 #include "../launch/node.h"
 #include "../fd_watcher.h"
 #include "../log_event.h"
+#include "log_parser.h"
 
 #include <ros/node_handle.h>
 
@@ -224,8 +225,8 @@ private:
 
 	FDWatcher::Ptr m_fdWatcher;
 
-	boost::circular_buffer<char> m_rxBuffer;
-	boost::circular_buffer<char> m_stderrBuffer;
+	LogParser m_stdoutParser;
+	LogParser m_stderrParser;
 
 	int m_pid = -1;
 	int m_fd = -1;

--- a/rosmon_core/src/monitor/node_monitor.h
+++ b/rosmon_core/src/monitor/node_monitor.h
@@ -5,6 +5,7 @@
 #define ROSMON_MONITOR_NODE_MONITOR_H
 
 #include "../launch/node.h"
+#include "../launch/launch_config.h"
 #include "../fd_watcher.h"
 #include "../log_event.h"
 #include "log_parser.h"
@@ -46,7 +47,8 @@ public:
 	 * @param nh ros::NodeHandle to use for creating timers
 	 **/
 	NodeMonitor(
-		launch::Node::ConstPtr launchNode,
+		const launch::LaunchConfig::ConstPtr& config,
+		const launch::Node::ConstPtr& launchNode,
 		FDWatcher::Ptr fdWatcher, ros::NodeHandle& nh);
 	~NodeMonitor();
 
@@ -221,6 +223,7 @@ private:
 
 	std::pair<int,int> createPTY();
 
+	launch::LaunchConfig::ConstPtr m_launchConfig;
 	launch::Node::ConstPtr m_launchNode;
 
 	FDWatcher::Ptr m_fdWatcher;

--- a/rosmon_core/src/ui.cpp
+++ b/rosmon_core/src/ui.cpp
@@ -491,6 +491,9 @@ void UI::log(const LogEvent& event)
 			case LogEvent::Type::Raw:
 			case LogEvent::Type::Info:
 				break;
+			case LogEvent::Type::Debug:
+				m_term.setSimpleForeground(Terminal::Green);
+				break;
 			case LogEvent::Type::Warning:
 				m_term.setSimpleForeground(Terminal::Yellow);
 				break;

--- a/rosmon_core/src/ui.cpp
+++ b/rosmon_core/src/ui.cpp
@@ -428,7 +428,7 @@ void UI::log(const LogEvent& event)
 	if(event.channel == LogEvent::Channel::Stdout && (!event.showStdout || stderrOnly()))
 		return;
 
-	const std::string& clean = event.message;
+	std::string clean = event.coloredString();
 
 	auto it = m_nodeColorMap.find(event.source);
 

--- a/rosmon_core/test/monitor/test_log_parser.cpp
+++ b/rosmon_core/test/monitor/test_log_parser.cpp
@@ -1,0 +1,63 @@
+// Test log parser
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#include <catch_ros/catch.hpp>
+
+#include "../../src/monitor/log_parser.h"
+
+using namespace rosmon::monitor;
+
+TEST_CASE("LogParser", "[log_parser]")
+{
+	LogParser parser;
+
+	int captures = 0;
+	LogParser::Event lastEvent;
+
+	auto cb = [&](LogParser::Event&& event){
+		captures++;
+		lastEvent = std::move(event);
+	};
+	parser.setCallback(cb);
+
+	SECTION("simple")
+	{
+		captures = 0;
+
+		parser.processString("\e[0mThis is an info message\e[0m\n");
+		CHECK(captures == 1);
+		CHECK(lastEvent.severity == rosmon::LogEvent::Type::Info);
+		CHECK(lastEvent.message == "This is an info message");
+
+		captures = 0;
+
+		parser.processString("\e[31mThis is an error message\e[0m\n");
+		CHECK(captures == 1);
+		CHECK(lastEvent.severity == rosmon::LogEvent::Type::Error);
+		CHECK(lastEvent.message == "This is an error message");
+
+		captures = 0;
+
+		parser.processString("\e[32mThis is a debug message\e[0m\n");
+		CHECK(captures == 1);
+		CHECK(lastEvent.severity == rosmon::LogEvent::Type::Debug);
+		CHECK(lastEvent.message == "This is a debug message");
+
+		captures = 0;
+
+		parser.processString("\e[33mThis is a warning message\e[0m\n");
+		CHECK(captures == 1);
+		CHECK(lastEvent.severity == rosmon::LogEvent::Type::Warning);
+		CHECK(lastEvent.message == "This is a warning message");
+	}
+
+	SECTION("raw")
+	{
+		captures = 0;
+
+		parser.processString("This is a raw \e[31mred\e[0m message\n");
+		CHECK(captures == 1);
+		CHECK(lastEvent.severity == rosmon::LogEvent::Type::Raw);
+		CHECK(lastEvent.message == "This is a raw \e[31mred\e[0m message");
+	}
+}

--- a/rosmon_core/test/test_node.py
+++ b/rosmon_core/test/test_node.py
@@ -11,7 +11,7 @@ rospy.init_node('test_node')
 pub = rospy.Publisher('~output', String, queue_size=10)
 
 def callback(data):
-	print("Test node got", repr(data))
+	rospy.loginfo("Test node got {}".format(data))
 	pub.publish(data.data)
 
 sub = rospy.Subscriber('~input', String, callback)


### PR DESCRIPTION
Instead of writing our own log files, we send our log output to the systemd journal (or BSD-style `/dev/log` via `syslog()`).

Components of this PR:
 * [x] Parse log output from nodes to determine severity
 * [x] Systemd journal client implementation (https://systemd.io/JOURNAL_NATIVE_PROTOCOL/)
     * [x] Increase SO_SNDBUF size
 * [x] Disable own logfile creation in nodes (see #157)