### PR TITLE
Add missing include to #include <boost/mpl/vector.hpp>

### DIFF
--- a/rosmon_core/src/launch/substitution_python.cpp
+++ b/rosmon_core/src/launch/substitution_python.cpp
@@ -13,6 +13,8 @@
 #include <boost/python/import.hpp>
 
 #include <boost/lexical_cast.hpp>
+	
+#include <boost/mpl/vector.hpp>
 
 namespace py = boost::python;
 


### PR DESCRIPTION
Fixes:
```
$SRC_DIR/ros-noetic-rosmon-core/src/work/src/launch/substitution_python.cpp: In function 'boost::python::api::object rosmon::launch::make_handler(F)':
$SRC_DIR/ros-noetic-rosmon-core/src/work/src/launch/substitution_python.cpp:32:29: error: 'vector' is not a member of 'boost::mpl'; did you mean 'vector'?
   32 |                 boost::mpl::vector<std::string, const std::string&>()
      |                             ^~~~~~
      |                             vector9
```