### PR TITLE
add auto-increment-spawn-delay feature

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -271,6 +271,20 @@ void LaunchConfig::parseString(const std::string& input, bool onlyArguments)
 		fmt::print("Loaded launch file in {:f}s\n", (ros::WallTime::now() - start).toSec());
 }
 
+void LaunchConfig::applyAutoIncrementSpawnDelayToAll(const ros::WallDuration& autoIncrementSpawnDelay)
+{
+	ros::WallDuration currentDelay(0, 0);
+
+	for(auto& node : m_nodes)
+	{
+		if(node->spawnDelay().isZero())
+		{
+			node->setSpawnDelay(currentDelay);
+			currentDelay += autoIncrementSpawnDelay;
+		}
+	}
+}
+
 void LaunchConfig::parseTopLevelAttributes(TiXmlElement* element)
 {
 	const char* name = element->Attribute("rosmon-name");

--- a/rosmon_core/src/launch/launch_config.h
+++ b/rosmon_core/src/launch/launch_config.h
@@ -201,6 +201,8 @@ public:
 	void parse(const std::string& filename, bool onlyArguments = false);
 	void parseString(const std::string& input, bool onlyArguments = false);
 
+	void applyAutoIncrementSpawnDelayToAll(const ros::WallDuration& autoIncrementSpawnDelay);
+
 	void evaluateParameters();
 
 	inline const std::map<std::string, XmlRpc::XmlRpcValue>& parameters() const


### PR DESCRIPTION
Hi,
We are using rosmon on some big launch files (> 100 nodes).
Launching all the nodes simultaneously gives us some problems on startup.
I added an option to auto increment the spawn delay of all the nodes (except those having already a spawn-delay set).

For example, with `--auto-increment-spawn-delay=1`
Node A will launch at 0s
Node B will launch at 1s
Node C will launch at 2s
