### PR TITLE
Fix compilation with clang

### DIFF
--- a/rosmon_core/src/logger.h
+++ b/rosmon_core/src/logger.h
@@ -15,6 +15,7 @@ namespace rosmon
 class Logger
 {
 public:
+	virtual ~Logger() = default;
 	virtual void log(const LogEvent& event) = 0;
 };
 
@@ -30,7 +31,7 @@ public:
 	 * @param path Path to the output file
 	 **/
 	explicit FileLogger(const std::string& path, bool flush = false);
-	~FileLogger();
+	~FileLogger() override;
 
 	//! Log message
 	void log(const LogEvent& event) override;
@@ -46,7 +47,6 @@ class SyslogLogger : public Logger
 {
 public:
 	explicit SyslogLogger(const std::string& launchFileName);
-	~SyslogLogger();
 
 	void log(const LogEvent& event) override;
 
@@ -69,7 +69,7 @@ public:
 	};
 
 	explicit SystemdLogger(const std::string& launchFileName);
-	~SystemdLogger();
+	~SystemdLogger() override;
 
 	void log(const LogEvent& event) override;
 


### PR DESCRIPTION
The correct way to do inheritance is to have a public virtual destructor, and base classes can overwrite it if needed. This fixes compilation of rosmon with clang.

See also this rule in the C++ Core Guidelines:
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-virtual