### PR TITLE
core: log_parser: fix state machine for multiple colored sections

### DIFF
--- a/rosmon_core/src/monitor/log_parser.cpp
+++ b/rosmon_core/src/monitor/log_parser.cpp
@@ -127,6 +127,8 @@ public:
 					m_state = State::ColorEscape1;
 					m_buffer.clear();
 				}
+				else
+					m_state = State::RawMsgContent;
 
 				break;
 

--- a/rosmon_core/test/monitor/test_log_parser.cpp
+++ b/rosmon_core/test/monitor/test_log_parser.cpp
@@ -59,6 +59,13 @@ TEST_CASE("LogParser", "[log_parser]")
 		CHECK(captures == 1);
 		CHECK(lastEvent.severity == rosmon::LogEvent::Type::Raw);
 		CHECK(lastEvent.message == "This is a raw \e[31mred\e[0m message");
+
+		captures = 0;
+
+		parser.processString("\e[33mThis is a warning message with an end\e[0m and another start \e[33m  and another end!\e[0m\n");
+		CHECK(captures == 1);
+		CHECK(lastEvent.severity == rosmon::LogEvent::Type::Raw);
+		CHECK(lastEvent.message == "\e[33mThis is a warning message with an end\e[0m and another start \e[33m  and another end!\e[0m");
 	}
 
 	SECTION("timeout")


### PR DESCRIPTION
Something like `"\e[33m First \e[0m and \e[32m second \e[0m"` would lead to rosmon only outputting `"First"`.

This also adds a corresponding test case.

See #178.