### PR TITLE
core: add an argument to keep colors in no ui mode

### DIFF
--- a/rosmon_core/src/main.cpp
+++ b/rosmon_core/src/main.cpp
@@ -34,6 +34,7 @@ namespace fs = boost::filesystem;
 
 bool g_shouldStop = false;
 bool g_flushStdout = false;
+bool g_withColors = false;
 
 static fs::path findFile(const fs::path& base, const std::string& name)
 {
@@ -65,6 +66,8 @@ void usage()
 		"\n"
 		"Options:\n"
 		"  --disable-ui    Disable fancy terminal UI\n"
+		"  --disable-ui-with-colors\n"
+		"                  Disable fancy terminal UI but keep colors in logs\n"
 		"  --flush-log     Flush logfile after writing an entry\n"
 		"  --flush-stdout  Flush stdout after writing an entry\n"
 		"  --help          This help screen\n"
@@ -114,7 +117,10 @@ void logToStdout(const rosmon::LogEvent& event, const int max_width)
 	if(event.channel == rosmon::LogEvent::Channel::Stdout && !event.showStdout)
 		return;
 
-	fmt::print("{:>{}}: {}", event.source, max_width, event.message);
+	if(g_withColors)
+		fmt::print("{:>{}}: {}", event.source, max_width, event.coloredString());
+	else
+		fmt::print("{:>{}}: {}", event.source, max_width, event.message);
 
 	if(!event.message.empty() && event.message.back() != '\n')
 		std::cout << '\n';
@@ -126,6 +132,7 @@ void logToStdout(const rosmon::LogEvent& event, const int max_width)
 // Options
 static const struct option OPTIONS[] = {
 	{"disable-ui", no_argument, nullptr, 'd'},
+	{"disable-ui-with-colors", no_argument, nullptr, 'w'},
 	{"benchmark", no_argument, nullptr, 'b'},
 	{"flush-log", no_argument, nullptr, 'f'},
 	{"flush-stdout", no_argument, nullptr, 'F'},
@@ -208,6 +215,10 @@ int main(int argc, char** argv)
 				break;
 			case 'd':
 				enableUI = false;
+				break;
+			case 'w':
+				enableUI = false;
+				g_withColors = true;
 				break;
 			case 'f':
 				flushLog = true;


### PR DESCRIPTION
Following my https://github.com/xqms/rosmon/issues/185#issuecomment-2136813205, here is a proposition about adding a mode to disable UI but keep the colors in the logs (or more precisely, adding colors based on the severity).

As explained in the issue, I have chosen to not detect if run in a TTY to enable colors automatically because in my use case, rosmon is started as a sub-process, hence not directly in a TTY.

I am not sure about the name of the argument and its short version, feel free to propose other names.

I am not a big fan of adding yet another global variable in main.cpp but I kept the same solution than when I have added the flush to stdout flag.