### PR TITLE
package_registry: fix slow startup with large catkin overlay workspaces

### DIFF
--- a/rosmon_core/src/package_registry.cpp
+++ b/rosmon_core/src/package_registry.cpp
@@ -61,9 +61,15 @@ struct CatkinWorkspace
 		fs::path catkinPath = path / ".catkin";
 		std::ifstream file{catkinPath.string()};
 
-		for(std::string line; std::getline(file, line);)
+		for(std::string path; std::getline(file, path, ';');)
 		{
-			for(fs::recursive_directory_iterator it(line); it != fs::recursive_directory_iterator(); ++it)
+			if(!fs::exists(path))
+			{
+				fmt::print(stderr, "Warning: source path '{}' found in '{}' does not exist.\n", path, catkinPath.string());
+				continue;
+			}
+
+			for(fs::recursive_directory_iterator it(path); it != fs::recursive_directory_iterator(); ++it)
 			{
 				if(it->path().filename() == "package.xml")
 					crawlSourcePackage(it->path());

--- a/rosmon_core/src/package_registry.cpp
+++ b/rosmon_core/src/package_registry.cpp
@@ -155,7 +155,7 @@ static std::string _getExecutable(const std::string& package, const std::string&
 	if(!g_initialized)
 		init();
 
-	// Try catkin libexec & catkin share first
+	// Phase 1: Try installed paths (lib/ and share/) across all workspaces
 	for(auto& workspace : g_catkin_workspaces)
 	{
 		fs::path execPath = workspace.path / "lib" / package / name;
@@ -165,8 +165,11 @@ static std::string _getExecutable(const std::string& package, const std::string&
 		std::string sharePath = getExecutableInPath(workspace.path / "share" / package, name);
 		if(!sharePath.empty())
 			return sharePath;
+	}
 
-		// Look in associated source directories of the workspace
+	// Phase 2: Fallback to source package directories (expensive on first call)
+	for(auto& workspace : g_catkin_workspaces)
+	{
 		workspace.crawlSourcePackages();
 
 		auto it = workspace.packageSourcePaths.find(package);
@@ -174,7 +177,7 @@ static std::string _getExecutable(const std::string& package, const std::string&
 			return getExecutableInPath(it->second, name);
 	}
 
-	// Crawl package directory for an appropriate executable
+	// Phase 3: Crawl package directory for an appropriate executable
 	std::string packageDir = PackageRegistry::getPath(package);
 	if(!packageDir.empty())
 		return getExecutableInPath(packageDir, name);
@@ -202,35 +205,40 @@ std::string PackageRegistry::findPathToFile(const std::string& package, const st
 	if(!g_initialized)
 		init();
 
-	// Try catkin libexec & catkin share first
+	// Phase 1: Check installed paths (lib/ and share/) across all workspaces
+	// Note: No X_OK check — this function resolves $(find pkg)/... paths which
+	// include launch files, configs, etc. that are not executable.
 	for(auto& workspace : g_catkin_workspaces)
 	{
 		fs::path execPath = workspace.path / "lib" / package;
 		fs::path filePath = execPath / name;
-		if(fs::exists(filePath) && access(filePath.c_str(), X_OK) == 0)
+		if(fs::exists(filePath))
 			return execPath.string();
 
 		fs::path sharePath = workspace.path / "share" / package;
 		filePath = sharePath / name;
-		if(fs::exists(filePath) && access(filePath.c_str(), X_OK) == 0)
+		if(fs::exists(filePath))
 			return sharePath.string();
+	}
 
-		// Look in associated source directories of the workspace
+	// Phase 2: Fallback to source package directories (expensive on first call)
+	for(auto& workspace : g_catkin_workspaces)
+	{
 		workspace.crawlSourcePackages();
 
 		auto it = workspace.packageSourcePaths.find(package);
 		if(it != workspace.packageSourcePaths.end())
 		{
 			fs::path filePath = it->second / name;
-			if(fs::exists(filePath) && access(filePath.c_str(), X_OK) == 0)
+			if(fs::exists(filePath))
 				return it->second.string();
 		}
 	}
 
-	// Try package directory (src)
+	// Phase 3: Try package directory via rospack
 	fs::path packageDir = PackageRegistry::getPath(package);
 	fs::path filePath = packageDir / name;
-	if(fs::exists(filePath) && access(filePath.c_str(), X_OK) == 0)
+	if(fs::exists(filePath))
 		return packageDir.string();
 
 	// Nothing found :-(


### PR DESCRIPTION
## Problem

When using rosmon with a catkin overlay workspace containing many source packages (~200+), startup takes ~48 seconds to parse a launch file that `roslaunch` handles in under 1 second.

The bottleneck is `crawlSourcePackages()` in `package_registry.cpp`, which does a `recursive_directory_iterator` over every source directory listed in the workspace's `.catkin` file, reading every `package.xml`. With large workspaces this is extremely expensive (~37s kernel time in filesystem operations).

## Root Cause

`findPathToFile()` — used to resolve `$(find pkg)/...` substitutions — checks files in catkin workspace `share/` and `lib/` directories using `access(path, X_OK)`. Since launch files, YAML configs, and other non-executable files fail the execute permission check, the function always falls through to `crawlSourcePackages()` even when the files exist in the installed workspace paths.

Additionally, both `_getExecutable()` and `findPathToFile()` call `crawlSourcePackages()` per-workspace as they iterate, meaning the expensive crawl is triggered on the first workspace that doesn't have the file in `lib/` or `share/` — before even checking installed paths in later workspaces.

## Fix

1. **Remove `X_OK` from `findPathToFile()`**: Use `fs::exists()` only. This function resolves `$(find pkg)/...` paths which include launch files, configs, etc. that are not executable. (`_getExecutable()` retains `X_OK` since it specifically looks for executables.)

2. **Defer `crawlSourcePackages()` to a last-resort phase**: Both `_getExecutable()` and `findPathToFile()` now check all workspaces' installed paths (`lib/`, `share/`) first, and only fall back to source package crawling if the file isn't found in any installed location.

## Result

`rosmon --benchmark` on a 16-file launch tree with a ~200-package overlay workspace:

| | Before | After |
|---|---|---|
| Wall time | 48.3s | 1.6s |
| User | 11.4s | 0.8s |
| Sys | 37.3s | 1.3s |

**30x speedup.** The source crawl is never triggered when packages are properly built in the workspace.
